### PR TITLE
provide a cr_once executable for testing purpose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ example/.compact-inc.cirru
 
 # Ignore all
 src/cr
+src/cr_once
 tests/test_expr
 tests/run_calcit
 tests/prof

--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -6,7 +6,7 @@ author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"
 srcDir        = "src"
-bin           = @["cr"]
+namedBin      = {"cr": "cr", "cr_once": "cr_once"}.toTable()
 binDir        = "out/"
 
 # Dependencies

--- a/src/cr_once.nim
+++ b/src/cr_once.nim
@@ -1,0 +1,8 @@
+
+import ./calcit_runner
+
+var snapshotFile = "compact.cirru"
+
+echo "Running calcit runner in CI mode"
+
+discard runProgram(snapshotFile)


### PR DESCRIPTION
The command `cr_once` has almost no dependency and probably can be used for CI testing.