### PR TITLE
fix edge case for mapcat

### DIFF
--- a/src/calcit_runner/core_abstract.nim
+++ b/src/calcit_runner/core_abstract.nim
@@ -354,7 +354,8 @@ proc loadCoreFuncs*(programCode: var Table[string, FileSource]) =
 
   let codeMapcat = genCirru(
     [defn, mapcat, [f, xs],
-      [concat, "&", [map, f, xs]]]
+      ["if", ["empty?", xs], ["[]"],
+        [concat, "&", [map, f, xs]]]]
   , coreNs)
 
   let codeMerge = genCirru(

--- a/tests/snapshots/test-list.cirru
+++ b/tests/snapshots/test-list.cirru
@@ -64,6 +64,18 @@
                   [] 1 2 3 4
                 [] 0 0 1 0 1 2 0 1 2 3
 
+              assert=
+                mapcat
+                  fn (x) (range x)
+                  [] 1
+                [] 0
+
+              assert=
+                mapcat
+                  fn (x) (range x)
+                  []
+                []
+
               assert |identity $ =
                 map identity $ range 10
                 range 10


### PR DESCRIPTION
`concat` does not handle empty list, worrying.