### PR TITLE
add sieve-primes example for looking into performance

### DIFF
--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -26,7 +26,7 @@ task once, "run once":
   exec "nim compile --verbosity:0 --hints:off --threads:on -r src/cr --once example/compact.cirru"
 
 task perf, "run with perf":
-  exec "nim compile --verbosity:0 --profiler:on --stackTrace:on --hints:off -r tests/prof"
+  exec "nim compile --profiler:on --stackTrace:on -r tests/prof"
 
 task t, "Runs the test suite":
   exec "nim c -r --hints:off --threads:on tests/test_expr.nim"

--- a/tests/prof.nim
+++ b/tests/prof.nim
@@ -1,7 +1,8 @@
 
 import nimprof
 import times
-import calcit_runner
+
+import ./calcit_runner
 
 let t1 = now()
 

--- a/tests/snapshots/fibo.cirru
+++ b/tests/snapshots/fibo.cirru
@@ -7,7 +7,10 @@
         ns app.main $ :require
       :defs $ {}
         |main! $ quote
-          defn main! () (println "\"Loaded program!") (try-fibo)
+          defn main! ()
+            println "\"Loaded program!"
+            ; try-fibo
+            echo $ sieve-primes ([] 2 3 5 7 11 13) 17 400
 
         |try-fibo $ quote
           defn try-fibo ()
@@ -19,6 +22,16 @@
           defn fibo (x)
             if (< x 2) (, 1)
               + (fibo $ - x 1) (fibo $ - x 2)
+
+        |sieve-primes $ quote
+          defn sieve-primes (acc n limit)
+            if (&> n limit) acc $ if
+              every?
+                fn (m)
+                  &> (mod n m) 0
+                , acc
+              recur (conj acc n) (inc n) (, limit)
+              recur acc (inc n) limit
 
       :proc $ quote ()
       :configs $ {} (:extension nil)


### PR DESCRIPTION
Problems in GC:

```
total executions of each stack trace:
Entry: 1/343 Calls: 7/428 = 1.64% [sum: 7; 7/428 = 1.64%]
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/comparisons.nim: <% 73/428 = 17.06%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/gc.nim: newObjNoInit 118/428 = 27.57%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssign 285/428 = 66.59%
  /Users/chen/.nimble/pkgs/ternary_tree-0.1.28/ternary_tree/list.nim: loopGet 118/428 = 27.57%
  /Users/chen/.nimble/pkgs/ternary_tree-0.1.28/ternary_tree/list.nim: [] 142/428 = 33.18%
  ...: ... 394/428 = 92.06%
  /Users/chen/repo/calcit-lang/calcit-runner/src/calcit_runner.nim: evaluateDefCode 394/428 = 92.06%
  /Users/chen/repo/calcit-lang/calcit-runner/src/calcit_runner.nim: runCode 394/428 = 92.06%
  /Users/chen/repo/calcit-lang/calcit-runner/src/calcit_runner.nim: runProgram 427/428 = 99.77%
Entry: 2/343 Calls: 6/428 = 1.40% [sum: 13; 13/428 = 3.04%]
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/arithmetics.nim: -% 65/428 = 15.19%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/gc.nim: usrToCell 52/428 = 12.15%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/gc.nim: newObjNoInit 118/428 = 27.57%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssignAux 309/428 = 72.20%
  /Users/chen/.choosenim/toolchains/nim-1.4.0/lib/system/assign.nim: genericAssign 285/428 = 66.59%
  /Users/chen/.nimble/pkgs/ternary_tree-0.1.28/ternary_tree/list.nim: loopGet 118/428 = 27.57%
  /Users/chen/.nimble/pkgs/ternary_tree-0.1.28/ternary_tree/list.nim: [] 142/428 = 33.18%
  /Users/chen/repo/calcit-lang/calcit-runner/src/calcit_runner/data.nim: [] 142/428 = 33.18%
  /Users/chen/repo/calcit-lang/calcit-runner/src/calcit_runner/data.nim: [] 142/428 = 33.18%
  /Users/chen/repo/calcit-lang/calcit-runner/src/calcit_runner/data.nim: [] 142/428 = 33.18%
  /Users/chen/repo/calcit-lang/calcit-runner/src/calcit_runner/evaluate.nim: interpret 361/428 = 84.35%
  /Users/chen/repo/calcit-lang/calcit-runner/src/calcit_runner/data.nim: spreadFuncArgs 189/428 = 44.16%
  ...: ... 394/428 = 92.06%
  /Users/chen/repo/calcit-lang/calcit-runner/src/calcit_runner.nim: evaluateDefCode 394/428 = 92.06%
  /Users/chen/repo/calcit-lang/calcit-runner/src/calcit_runner.nim: runCode 394/428 = 92.06%
  /Users/chen/repo/calcit-lang/calcit-runner/src/calcit_runner.nim: runProgram 427/428 = 99.77%

...

```