### PR TITLE
experimental implementation for event loops, new function timeout-call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ src/*.out
 
 profile_results.txt
 calcit_runner_*.nims
+
+js-out/*

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ nimble once
 
 # demo of eval from CLI
 nimble e
+
+# for emitting js
+nimble jsgen
 ```
 
 ### Modules

--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -39,3 +39,6 @@ task ct, "Runs calcit tests":
 
 task e, "eval some code":
   exec "nim compile --verbosity:0 --hints:off --threads:on -r src/cr -e='range 10'"
+
+task jsgen, "try js":
+  exec "nim compile --verbosity:0 --hints:off --threads:on -r src/cr --emit-js example/compact.cirru"

--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -1,7 +1,7 @@
 
 # Package
 
-version       = "0.2.5"
+version       = "0.2.6"
 author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"

--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -1,7 +1,7 @@
 
 # Package
 
-version       = "0.2.4"
+version       = "0.2.5"
 author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"

--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -1,7 +1,7 @@
 
 # Package
 
-version       = "0.2.3"
+version       = "0.2.4"
 author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"

--- a/example/calcit.cirru
+++ b/example/calcit.cirru
@@ -139,6 +139,7 @@
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1605610897282) (:text |a)
                       |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1605610632239) (:text |1)
+                  |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608952397667) (:text |;)
               |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1598199469694) (:text |main!)
               |v $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1598199471640)
                 :data $ {}
@@ -156,6 +157,7 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1605610637258) (:text |echo)
                   |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1605610637258) (:text |[,])
+                  |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608952400853) (:text |;)
               |yyyyyD $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608895790590)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608895793144) (:text |try-timeout)
@@ -163,6 +165,7 @@
               |yyyyx $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604160743867)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604812601556) (:text |draw/try-canvas)
+                  |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608952396808) (:text |;)
               |yvT $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600585355117)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600585359363) (:text |try-func)
@@ -459,7 +462,7 @@
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896086066) (:text |*)
                           |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896086066) (:text |idx)
-                          |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896086066) (:text |200)
+                          |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608954038697) (:text |80)
                       |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608896086066)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896086066) (:text |fn)
@@ -475,7 +478,7 @@
                       |j $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608896081031)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896082706) (:text |range)
-                          |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896083055) (:text |20)
+                          |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608955056977) (:text |40)
               |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608895800557) (:data $ {})
               |yyr $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608895803542)
                 :data $ {}

--- a/example/calcit.cirru
+++ b/example/calcit.cirru
@@ -125,6 +125,9 @@
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1601550068492) (:text |try-edn)
                   |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1601637136981) (:text |;)
               |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1598199469694) (:text |defn)
+              |yyyyyn $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608983333152)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983337266) (:text |try-thunk)
               |yyyyv $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1603269417132)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1603269418598) (:text |try-json)
@@ -153,19 +156,22 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600749282366) (:text |try-var-args)
                   |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600915728906) (:text |;)
+              |yyyyyb $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608983333152)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983337266) (:text |try-thunk)
               |yyyyvT $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1605610636875)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1605610637258) (:text |echo)
                   |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1605610637258) (:text |[,])
                   |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608952400853) (:text |;)
-              |yyyyyD $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608895790590)
+              |yyyyy5 $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604749842566)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608895793144) (:text |try-timeout)
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604749845767) (:text |try-atom)
               |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1598199469694) (:data $ {})
               |yyyyx $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604160743867)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604812601556) (:text |draw/try-canvas)
-                  |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608952396808) (:text |;)
+                  |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608985365918) (:text |;)
               |yvT $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600585355117)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600585359363) (:text |try-func)
@@ -173,7 +179,9 @@
               |yyyyy $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604749842566)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604749845767) (:text |try-atom)
-                  |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604810749299) (:text |;)
+              |yyyyyt $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608985376086)
+                :data $ {}
+                  |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608985376086) (:text |try-timeout)
           |try-hygienic $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600661170630)
             :data $ {}
               |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600661171927) (:text |defn)
@@ -360,6 +368,16 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600661117660) (:text |a)
                   |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600661118065) (:text |b)
+          |try-thunk $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608983379800)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983384714) (:text |defn)
+              |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983379800) (:text |try-thunk)
+              |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608983385727) (:data $ {})
+              |v $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608983386766)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983387469) (:text |echo)
+                  |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983424976) (:text "|\"running thunk with data:")
+                  |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983410195) (:text |demo-thunk-data)
           |try-var-args $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600749523896)
             :data $ {}
               |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600749523896) (:text |defn)
@@ -383,13 +401,20 @@
             :data $ {}
               |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604749863193) (:text |defatom)
               |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604749861225) (:text |*state-a)
-              |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604749865967)
+              |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608984967961)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604749866330) (:text |{})
-                  |j $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604749866724)
+                  |T $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604749865967)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604749871731) (:text |:count)
-                      |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604749872209) (:text |0)
+                      |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604749866330) (:text |{})
+                      |j $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604749866724)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604749871731) (:text |:count)
+                          |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604749872209) (:text |0)
+                  |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608984968555) (:text |do)
+                  |L $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608984969988)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608984970797) (:text |echo)
+                      |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608984978509) (:text "|\"initilizing state a")
           |try-atom $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604749847699)
             :data $ {}
               |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604749847699) (:text |defn)
@@ -429,6 +454,13 @@
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604750699246) (:text |remove-watch)
                   |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604750700745) (:text |*state-a)
                   |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604750703091) (:text |:a)
+              |w $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608985009149)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608985016126) (:text |swap!)
+                  |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608985024481) (:text |*state-a)
+                  |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608985025677) (:text |update)
+                  |v $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608985029596) (:text |:count)
+                  |x $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608985033463) (:text |inc)
           |try-edn $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1601550070197)
             :data $ {}
               |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1601550070197) (:text |defn)
@@ -533,6 +565,24 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604811726850) (:text |reload-atom)
                   |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1604811757681) (:text |;)
+          |demo-thunk-data $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608983339337)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983345778) (:text |def)
+              |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983407875) (:text |demo-thunk-data)
+              |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608983360645)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983360880) (:text |do)
+                  |j $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608983361273)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983362411) (:text |echo)
+                      |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983368399) (:text "|\"inside a chunk")
+                  |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608983372614)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983373031) (:text |+)
+                      |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983373883) (:text |1)
+                      |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983374117) (:text |2)
+                      |v $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983374367) (:text |3)
+                      |x $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608983374622) (:text |4)
           |var-fn $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600749282888)
             :data $ {}
               |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600749285676) (:text |defn)

--- a/example/calcit.cirru
+++ b/example/calcit.cirru
@@ -156,6 +156,9 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1605610637258) (:text |echo)
                   |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1605610637258) (:text |[,])
+              |yyyyyD $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608895790590)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608895793144) (:text |try-timeout)
               |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1598199469694) (:data $ {})
               |yyyyx $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1604160743867)
                 :data $ {}
@@ -438,6 +441,46 @@
                           |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1601550075500) (:text |load-cirru-edn)
                           |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1601550087408) (:text "|\"./example/compact.cirru")
                       |D $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1601550137101) (:text |str)
+          |try-timeout $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608895800557)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608895802297) (:text |defn)
+              |yyyj $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608895803542)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608895803542) (:text |echo)
+                  |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608895803542) (:text "|\"next")
+              |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608895800557) (:text |try-timeout)
+              |yyu $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608895914940)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896093708) (:text |&doseq)
+                  |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608896086066)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896086066) (:text |timeout-call)
+                      |j $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608896086066)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896086066) (:text |*)
+                          |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896086066) (:text |idx)
+                          |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896086066) (:text |200)
+                      |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608896086066)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896086066) (:text |fn)
+                          |j $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608896086066) (:data $ {})
+                          |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608896086066)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896086066) (:text |echo)
+                              |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896086066) (:text "|\"finished:")
+                              |r $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896086066) (:text |idx)
+                  |f $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608896078881)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896079902) (:text |idx)
+                      |j $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608896081031)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896082706) (:text |range)
+                          |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608896083055) (:text |20)
+              |r $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608895800557) (:data $ {})
+              |yyr $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1608895803542)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608895803542) (:text |echo)
+                  |j $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1608895803542) (:text "|\"timeout")
           |gen-num $ {} (:type :expr) (:by |Bka0vFjNW) (:at 1600533388568)
             :data $ {}
               |T $ {} (:type :leaf) (:by |Bka0vFjNW) (:at 1600533391697) (:text |defmacro)

--- a/example/compact.cirru
+++ b/example/compact.cirru
@@ -16,9 +16,9 @@
               echo $ stringify-json new-data
               write-file "\"codes-new.json" (stringify-json new-data) 
         |main! $ quote
-          defn main! () (println "\"Loaded program!") (; try-func) (; try-hygienic) (; try-var-args) (; try-edn) (; try-json) (echo [,])
-            echo $ fn (a) 1
-            draw/try-canvas
+          defn main! () (println "\"Loaded program!") (; try-func) (; try-hygienic) (; try-var-args) (; try-edn) (; try-json) (; echo [,])
+            ; echo $ fn (a) 1
+            ; draw/try-canvas
             ; try-atom
             try-timeout
         |try-hygienic $ quote
@@ -61,8 +61,8 @@
             echo $ str (load-cirru-edn "\"./example/compact.cirru")
         |try-timeout $ quote
           defn try-timeout () (echo "\"timeout")
-            &doseq (idx $ range 20)
-              timeout-call (* idx 200)
+            &doseq (idx $ range 40)
+              timeout-call (* idx 80)
                 fn () (echo "\"finished:" idx)
             echo "\"next"
         |gen-num $ quote

--- a/example/compact.cirru
+++ b/example/compact.cirru
@@ -20,6 +20,7 @@
             echo $ fn (a) 1
             draw/try-canvas
             ; try-atom
+            try-timeout
         |try-hygienic $ quote
           defn try-hygienic ()
             let
@@ -58,6 +59,12 @@
         |try-edn $ quote
           defn try-edn ()
             echo $ str (load-cirru-edn "\"./example/compact.cirru")
+        |try-timeout $ quote
+          defn try-timeout () (echo "\"timeout")
+            &doseq (idx $ range 20)
+              timeout-call (* idx 200)
+                fn () (echo "\"finished:" idx)
+            echo "\"next"
         |gen-num $ quote
           defmacro gen-num (a b c) (echo "\"expanding..." a b c) (quote $ + 1 2 3)
         |reload! $ quote

--- a/example/compact.cirru
+++ b/example/compact.cirru
@@ -19,7 +19,10 @@
           defn main! () (println "\"Loaded program!") (; try-func) (; try-hygienic) (; try-var-args) (; try-edn) (; try-json) (; echo [,])
             ; echo $ fn (a) 1
             ; draw/try-canvas
-            ; try-atom
+            try-atom
+            try-atom
+            try-thunk
+            try-thunk
             try-timeout
         |try-hygienic $ quote
           defn try-hygienic ()
@@ -48,12 +51,14 @@
               echo "\"internal c:" a b c
               quote-replace $ do (echo "\"c is:" c)
                 + (~ a) (~ b) (, c)
+        |try-thunk $ quote
+          defn try-thunk () (echo "\"running thunk with data:" demo-thunk-data)
         |try-var-args $ quote
           defn try-var-args () (var-fn 1 2 3 4) (var-macro a b c d)
         |*state-a $ quote
-          defatom *state-a $ {} (:count 0)
+          defatom *state-a $ do (echo "\"initilizing state a") ({} $ :count 0)
         |try-atom $ quote
-          defn try-atom () (echo *state-a) (echo $ deref *state-a)
+          defn try-atom () (echo *state-a) (echo $ deref *state-a) (swap! *state-a update :count inc)
             add-watch *state-a :a $ fn (a b) (echo "\"change happened:" a b)
             remove-watch *state-a :a
         |try-edn $ quote
@@ -69,6 +74,8 @@
           defmacro gen-num (a b c) (echo "\"expanding..." a b c) (quote $ + 1 2 3)
         |reload! $ quote
           defn reload! () (println "\"Reloaded..." $ inc10 4) (; main!) (draw/try-redraw-canvas) (; reload-atom)
+        |demo-thunk-data $ quote
+          def demo-thunk-data $ do (echo "\"inside a chunk") (+ 1 2 3 4)
         |var-fn $ quote
           defn var-fn (a & xs) (echo a xs)
         |on-error $ quote

--- a/src/calcit-core.cirru
+++ b/src/calcit-core.cirru
@@ -70,6 +70,9 @@
         |apply $ quote
           defn apply (f args) $ f & args
 
+        |apply-args $ quote
+          defn apply-args (args f) $ f & args
+
         |list? $ quote
           defn list? (x) $ &= (type-of x) :list
 
@@ -167,21 +170,21 @@
 
         |index-of $ quote
           defn index-of (xs0 item)
-            loop
-                idx 0
-                xs xs0
-              if (empty? xs) nil
-                if (&= item (first xs)) idx
-                  recur (&+ 1 idx) (rest xs)
+            apply-args
+              [] 0 xs0
+              fn (idx xs)
+                if (empty? xs) nil
+                  if (&= item (first xs)) idx
+                    recur (&+ 1 idx) (rest xs)
 
         |find-index $ quote
           defn find-index (f xs0)
-            loop
-                idx 0
-                xs xs0
-              if (empty? xs) nil
-                if (f (first xs)) idx
-                  recur (&+ 1 idx) f (rest xs)
+            apply-args
+              [] 0 xs0
+              fn (idx xs)
+                if (empty? xs) nil
+                  if (f (first xs)) idx
+                    recur (&+ 1 idx) f (rest xs)
 
         |find $ quote
           defn find (f xs)
@@ -319,15 +322,14 @@
 
         |map-indexed $ quote
           defn map-indexed (f xs)
-            loop
-                acc ([])
-                idx 0
-                ys xs
-              if (empty? ys) acc
-                recur
-                  append acc (f idx (first ys))
-                  &+ idx 1
-                  rest ys
+            apply-args
+              [] ([]) 0 xs
+              fn (acc idx ys)
+                if (empty? ys) acc
+                  recur
+                    append acc (f idx (first ys))
+                    &+ idx 1
+                    rest ys
 
         |filter $ quote
           defn filter (f xs)
@@ -361,17 +363,16 @@
 
         |zipmap $ quote
           defn zipmap (xs0 ys0)
-            loop
-                acc $ {}
-                xs xs0
-                ys ys0
-              if
-                &or (empty? xs) (empty? ys)
-                , acc
-                recur
-                  assoc acc (first xs) (first ys)
-                  rest xs
-                  rest ys
+            apply-args
+              [] ({})xs0 ys0
+              fn (acc xs ys)
+                if
+                  &or (empty? xs) (empty? ys)
+                  , acc
+                  recur
+                    assoc acc (first xs) (first ys)
+                    rest xs
+                    rest ys
 
         |rand-nth $ quote
           defn rand-nth (xs)
@@ -381,13 +382,14 @@
         |contains-symbol? $ quote
           defn contains-symbol? (xs y)
             if (list? xs)
-              loop
-                  body xs
-                if (empty? body) false
-                  if
-                    contains-symbol? (first body) y
-                    , true
-                    recur (rest body)
+              apply-args
+                [] xs
+                fn (body)
+                  if (empty? body) false
+                    if
+                      contains-symbol? (first body) y
+                      , true
+                      recur (rest body)
               &= xs y
 
         |\ $ quote
@@ -421,18 +423,18 @@
 
         |group-by $ quote
           defn group-by (f xs0)
-            loop
-                acc $ {}
-                xs xs0
-              if (empty? xs) acc
-                let
-                    x0 $ first xs
-                    key $ f x0
-                  recur
-                    if (contains? acc key)
-                      update acc key $ \ append % x0
-                      assoc acc key $ [] x0
-                    rest xs
+            apply-args
+              [] ({}) xs0
+              fn (acc xs)
+                if (empty? xs) acc
+                  let
+                      x0 $ first xs
+                      key $ f x0
+                    recur
+                      if (contains? acc key)
+                        update acc key $ \ append % x0
+                        assoc acc key $ [] x0
+                      rest xs
 
         |keys $ quote
           defn keys (x)
@@ -445,28 +447,28 @@
         |frequencies $ quote
           defn frequencies (xs0)
             assert "|expects a list for frequencies" (list? xs0)
-            loop
-                acc $ {}
-                xs xs0
-              &let
-                x0 (first xs)
-                if (empty? xs) acc
-                  recur
-                    if (contains? acc (first xs))
-                      update acc (first xs) (\ &+ % 1)
-                      assoc acc (first xs) 1
-                    rest xs
+            apply-args
+              [] ({}) xs0
+              fn (acc xs)
+                &let
+                  x0 (first xs)
+                  if (empty? xs) acc
+                    recur
+                      if (contains? acc (first xs))
+                        update acc (first xs) (\ &+ % 1)
+                        assoc acc (first xs) 1
+                      rest xs
 
         |section-by $ quote
           defn section-by (n xs0)
-            loop
-                acc $ []
-                xs xs0
-              if (&<= (count xs) n)
-                append acc xs
-                recur
-                  append acc (take n xs)
-                  drop n xs
+            apply-args
+              [] ([]) xs0
+              fn (acc xs)
+                if (&<= (count xs) n)
+                  append acc xs
+                  recur
+                    append acc (take n xs)
+                    drop n xs
 
         |[][] $ quote
           defmacro [][] (& xs)
@@ -561,8 +563,8 @@
 
         |loop $ quote
           defmacro loop (pairs & body)
-            assert "|loops requires pairs" (list? pairs)
-            assert "|loops requires pairs in pairs"
+            assert "|expects pairs in loop" (list? pairs)
+            assert "|expects pairs in pairs in loop"
               every?
                 defn detect-pairs? (x)
                   &and (list? x)
@@ -648,7 +650,8 @@
 
         |join-str $ quote
           defn join-str (sep xs0)
-            apply
+            apply-args
+              [] | xs0 true
               fn (acc xs beginning?)
                 if (empty? xs) acc
                   recur
@@ -657,11 +660,11 @@
                       first xs
                     rest xs
                     , false
-              [] | xs0 true
 
         |join $ quote
           defn join (sep xs0)
-            apply
+            apply-args
+              [] ([]) xs0 true
               fn (acc xs beginning?)
                 if (empty? xs) acc
                   recur
@@ -670,19 +673,19 @@
                       first xs
                     rest xs
                     , false
-              [] ([]) xs0 true
 
         |repeat $ quote
           defn quote (n0 x)
-            apply
+            apply-args
+              [] ([]) n0
               fn (acc n)
                 if (&<= n 0) acc
                   recur (append acc x) (&- n 1)
-              [] ([]) n0
 
         |interleave $ quote
           defn interleave (xs0 ys0)
-            apply
+            apply-args
+              [] ([]) xs0 ys0
               fn (acc xs ys)
                 if
                   &or (empty? xs) (empty? ys)
@@ -691,7 +694,6 @@
                     -> acc (append (first xs)) (append (first ys))
                     rest xs
                     rest ys
-              [] ([]) xs0 ys0
 
         |map-kv $ quote
           defn map-kv (f dict)

--- a/src/calcit-core.cirru
+++ b/src/calcit-core.cirru
@@ -816,3 +816,15 @@
                         [] x ([] (turn-keyword x) var-result)
                       , items
                     ~@ body
+
+        |conf $ quote
+          def conf append
+
+        |turn-str $ quote
+          def turn-str turn-string
+
+        |reduce $ quote
+          def reduce foldl
+
+        |dbt $ quote
+          def dbt dual-balanced-ternary

--- a/src/calcit_runner.nim
+++ b/src/calcit_runner.nim
@@ -23,6 +23,7 @@ import calcit_runner/gen_data
 import calcit_runner/evaluate
 import calcit_runner/eval_util
 import calcit_runner/gen_code
+import calcit_runner/emit_js
 
 export CirruData, CirruDataKind, `==`, crData
 
@@ -64,7 +65,11 @@ proc displayErrorMessage(message: string) =
 
 proc runCode(ns: string, def: string, argData: CirruData, dropArg: bool = false): CirruData =
   try:
-    return evaluateDefCode(ns, def, argData, dropArg)
+    if jsMode:
+      preprocessSymbolByPath(ns, def)
+      emitJs(programData, ns, def)
+    else:
+      return evaluateDefCode(ns, def, argData, dropArg)
 
   except CirruEvalError as e:
     displayErrorMessage(e.msg & " " & $e.code)

--- a/src/calcit_runner/core_func.nim
+++ b/src/calcit_runner/core_func.nim
@@ -1257,14 +1257,12 @@ proc loadCoreDefs*(programData: var Table[string, ProgramFile], interpret: FnInt
   programData[coreNs].defs["pr-str"] = CirruData(kind: crDataProc, procVal: nativePrStr)
   programData[coreNs].defs["prepend"] = CirruData(kind: crDataProc, procVal: nativePrepend)
   programData[coreNs].defs["append"] = CirruData(kind: crDataProc, procVal: nativeAppend)
-  programData[coreNs].defs["conj"] = CirruData(kind: crDataProc, procVal: nativeAppend) # an alias
   programData[coreNs].defs["first"] = CirruData(kind: crDataProc, procVal: nativeFirst)
   programData[coreNs].defs["empty?"] = CirruData(kind: crDataProc, procVal: nativeEmptyQuestion)
   programData[coreNs].defs["last"] = CirruData(kind: crDataProc, procVal: nativeLast)
   programData[coreNs].defs["butlast"] = CirruData(kind: crDataProc, procVal: nativeButlast)
   programData[coreNs].defs["reverse"] = CirruData(kind: crDataProc, procVal: nativeReverse)
   programData[coreNs].defs["turn-string"] = CirruData(kind: crDataProc, procVal: nativeTurnString)
-  programData[coreNs].defs["turn-str"] = CirruData(kind: crDataProc, procVal: nativeTurnString) # alias, deprecating in future
   programData[coreNs].defs["turn-symbol"] = CirruData(kind: crDataProc, procVal: nativeTurnSymbol)
   programData[coreNs].defs["turn-keyword"] = CirruData(kind: crDataProc, procVal: nativeTurnKeyword)
   programData[coreNs].defs["identical?"] = CirruData(kind: crDataProc, procVal: nativeIdenticalQuestion)
@@ -1297,7 +1295,6 @@ proc loadCoreDefs*(programData: var Table[string, ProgramFile], interpret: FnInt
   programData[coreNs].defs["&intersection"] = CirruData(kind: crDataProc, procVal: nativeIntersection)
   programData[coreNs].defs["recur"] = CirruData(kind: crDataProc, procVal: nativeRecur)
   programData[coreNs].defs["foldl"] = CirruData(kind: crDataProc, procVal: nativeFoldl)
-  programData[coreNs].defs["reduce"] = CirruData(kind: crDataProc, procVal: nativeFoldl) # alias
   programData[coreNs].defs["rand"] = CirruData(kind: crDataProc, procVal: nativeRand)
   programData[coreNs].defs["rand-int"] = CirruData(kind: crDataProc, procVal: nativeRandInt)
   programData[coreNs].defs["replace"] = CirruData(kind: crDataProc, procVal: nativeReplace)
@@ -1324,7 +1321,6 @@ proc loadCoreDefs*(programData: var Table[string, ProgramFile], interpret: FnInt
   programData[coreNs].defs["format-number"] = CirruData(kind: crDataProc, procVal: nativeFormatNumber)
   programData[coreNs].defs["sort"] = CirruData(kind: crDataProc, procVal: nativeSort)
   programData[coreNs].defs["dual-balanced-ternary"] = CirruData(kind: crDataProc, procVal: nativeDualBalancedTernary)
-  programData[coreNs].defs["dbt"] = CirruData(kind: crDataProc, procVal: nativeDualBalancedTernary) # alias
   programData[coreNs].defs["dbt->point"] = CirruData(kind: crDataProc, procVal: nativeDbtToPoint)
   programData[coreNs].defs["quit"] = CirruData(kind: crDataProc, procVal: nativeQuit)
   programData[coreNs].defs["get-env"] = CirruData(kind: crDataProc, procVal: nativeGetEnv)

--- a/src/calcit_runner/core_func.nim
+++ b/src/calcit_runner/core_func.nim
@@ -210,6 +210,8 @@ proc nativeTypeOf(args: seq[CirruData], interpret: FnInterpret, scope: CirruData
     of crDataSymbol: CirruData(kind: crDataKeyword, keywordVal: loadKeyword("symbol"))
     of crDataAtom: CirruData(kind: crDataKeyword, keywordVal: loadKeyword("atom"))
     of crDataTernary: CirruData(kind: crDataKeyword, keywordVal: loadKeyword("ternary"))
+    # TODO better extract thunk in such cases
+    of crDataThunk: CirruData(kind: crDataKeyword, keywordVal: loadKeyword("thunk"))
 
 proc nativeReadFile(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
   if args.len != 1:

--- a/src/calcit_runner/core_func.nim
+++ b/src/calcit_runner/core_func.nim
@@ -433,9 +433,9 @@ proc nativeIdenticalQuestion(args: seq[CirruData], interpret: FnInterpret, scope
   of crDataNil:
     return CirruData(kind: crDataBool, boolVal: true)
   of crDataString:
-    return CirruData(kind: crDataBool, boolVal: cast[pointer](a.stringVal) == cast[pointer](b.stringVal))
+    return CirruData(kind: crDataBool, boolVal: a.stringVal == b.stringVal)
   of crDataSymbol:
-    return CirruData(kind: crDataBool, boolVal: cast[pointer](a.symbolVal) == cast[pointer](b.symbolVal))
+    return CirruData(kind: crDataBool, boolVal: a.symbolVal == b.symbolVal)
   of crDataBool:
     return CirruData(kind: crDataBool, boolVal: a.boolVal == b.boolVal)
   of crDataNumber:

--- a/src/calcit_runner/emit_js.nim
+++ b/src/calcit_runner/emit_js.nim
@@ -1,0 +1,24 @@
+
+import tables
+
+import ./types
+
+# TODO dirty states controlling js backend
+var jsMode* = false
+var jsEmitPath* = "js-out"
+
+proc emitJs*(programData: Table[string, ProgramFile], entryNs, entryDef: string): void =
+  for ns, file in programData:
+    echo "ns: ", ns
+    echo "imports: ", file.ns
+    echo "defs"
+    for def, f in file.defs:
+      case f.kind
+      of crDataProc:
+        echo " proc: ", def
+      of crDataFn:
+        echo " fn: ", def, " ", f
+      of crDataThunk:
+        echo " thunk: ", def
+      else:
+        echo " ...well ", $f.kind

--- a/src/calcit_runner/emit_js.nim
+++ b/src/calcit_runner/emit_js.nim
@@ -24,7 +24,7 @@ proc toJsFileName(ns: string): string =
 
 proc escapeVar(name: string): string =
   name
-  .replace("-", "_")
+  .replace("-", "_SUBS_")
   .replace("?", "_QUES_")
   .replace("+", "_ADD_")
   .replace(">", "_SHR_")
@@ -39,6 +39,9 @@ proc escapeVar(name: string): string =
   .replace("!", "_BANG_")
   .replace("%", "_PCT_")
   .replace("/", "_SLSH_")
+  .replace("=", "_EQ_")
+  .replace(">", "_GT_")
+  .replace("<", "_LT_")
 
 proc toJsCode(xs: CirruData): string =
   case xs.kind

--- a/src/calcit_runner/emit_js.nim
+++ b/src/calcit_runner/emit_js.nim
@@ -1,24 +1,179 @@
 
+import os
+import strutils
 import tables
+import options
+import strformat
+
+import ternary_tree
 
 import ./types
+import ./errors
+
+const cLine = "\n"
+const cCurlyL = "{"
+const cCurlyR = "}"
+const cDbQuote = "\""
 
 # TODO dirty states controlling js backend
 var jsMode* = false
 var jsEmitPath* = "js-out"
 
+proc toJsFileName(ns: string): string =
+  ns & ".mjs"
+
+proc escapeVar(name: string): string =
+  name
+  .replace("-", "_")
+  .replace("?", "_QUES_")
+  .replace("+", "_ADD_")
+  .replace(">", "_SHR_")
+  .replace("*", "_STAR_")
+  .replace("&", "_AND_")
+  .replace("{}", "_MAP_")
+  .replace("[]", "_LIST_")
+  .replace("{", "_CURL_")
+  .replace("}", "_CURR_")
+  .replace("[", "_SQRL_")
+  .replace("]", "_SQRR_")
+  .replace("!", "_BANG_")
+  .replace("%", "_PCT_")
+  .replace("/", "_SLSH_")
+
+proc toJsCode(xs: CirruData): string =
+  case xs.kind
+  of crDataSymbol:
+    result = result & "caclit.core." & xs.symbolVal.escapeVar() & " "
+  of crDataString:
+    result = result & xs.stringVal.escape() & " "
+  of crDataBool:
+    result = result & $xs.boolVal & " "
+  of crDataNumber:
+    result = result & $xs.numberVal & " "
+  of crDataNil:
+    result = result & "null "
+  of crDataKeyword:
+    result = result & "calcit.core.turn_keyword(" & xs.keywordVal[].escape() & ")"
+  of crDataList:
+    if xs.listVal.len == 0:
+      return "()"
+    let head = xs.listVal[0]
+    let body = xs.listVal.rest()
+    if head.kind == crDataSymbol:
+      case head.symbolVal
+      of "if":
+        if body.len < 2:
+          raiseEvalError("need branches for if", xs)
+        let falseBranch = if body.len >= 3: body[2].toJsCode() else: "null"
+        return body[0].toJsCode() & "?" & body[1].toJsCode() & ":" & falseBranch
+      of "&let":
+        result = result & "(()=>{"
+        if body.len <= 1:
+          raiseEvalError("Unpexpected empty content in let", xs)
+        let pair = body.first()
+        let content = body.rest()
+        if pair.kind != crDataList:
+          raiseEvalError("Expected pair a list of length 2", pair)
+        if pair.listVal.len != 2:
+          raiseEvalError("Expected pair of length 2", pair)
+        let defName = pair.listVal[0]
+        if defName.kind != crDataSymbol:
+          raiseEvalError("Expected symbol behind let", pair)
+        result = result & fmt"let {defName.symbolVal.escapeVar} = {pair.listVal[1].toJsCode};{cLine}"
+        for x in content:
+          result = result & x.toJsCode() & "\n"
+        return result & "})()"
+      of ";":
+        return "// " & $body & "\n"
+      of "do":
+        result = "(()=>{"
+        for x in body:
+          if result != "(":
+            result = result & ";\n"
+          result = result & x.toJsCode()
+        result = result & "})()"
+        return result
+
+      of "quote":
+        if body.len < 1:
+          raiseEvalError("Unpexpected empty body", xs)
+        return ($body[0]).escape()
+      of "defatom":
+        # TODO
+        discard
+      of "defn":
+        # TODO
+        discard
+      of "defmacro":
+        return "/* Unpexpected macro " & $xs & " */"
+      of "quote-replace":
+        return "/* Unpexpected quote-replace " & $xs & " */"
+      else:
+        discard
+    var argsCode = ""
+    for x in body:
+      if argsCode != "":
+        argsCode = argsCode & ", "
+      argsCode = argsCode & x.toJsCode()
+    result = result & head.toJsCode() & "(" & argsCode & ")"
+  else:
+    echo "[WARNING] unknown kind to gen js code: ", xs.kind
+
+proc toJsCode(xs: seq[CirruData]): string =
+  for x in xs:
+    # result = result & "// " & $x & "\n"
+    result = result & x.toJsCode() & ";\n"
+
 proc emitJs*(programData: Table[string, ProgramFile], entryNs, entryDef: string): void =
+  if dirExists(jsEmitPath).not:
+    createDir(jsEmitPath)
   for ns, file in programData:
-    echo "ns: ", ns
-    echo "imports: ", file.ns
-    echo "defs"
+    let jsFilePath = joinPath(jsEmitPath, ns.toJsFileName())
+    var content = fmt"{cLine}import calcit_core from {cDbQuote}http://js/calcit-lang.org/calcit.core.mjs{cDbQuote};{cLine}"
+    echo ""
+    echo ""
+    if file.ns.isSome():
+      let importsInfo = file.ns.get()
+      for importName, importRule in importsInfo:
+        let importTarget = importRule.ns.toJsFileName()
+        case importRule.kind
+        of importDef:
+          content = content & fmt"{cLine}import {cCurlyL}{importName.escapeVar}{cCurlyR} from {cDbQuote}./{importTarget}{cDbQuote};{cLine}"
+        of importNs:
+          content = content & fmt"{cLine}import {importName.escapeVar} from {cDbQuote}./{importTarget}{cDbQuote};{cLine}"
+    else:
+      echo "[WARNING] no imports information for ", ns
     for def, f in file.defs:
       case f.kind
       of crDataProc:
-        echo " proc: ", def
+        # core proc are provided via lib
+        discard
       of crDataFn:
-        echo " fn: ", def, " ", f
+        var argsCode = ""
+        var spreading = false
+        for x in f.fnArgs:
+          if spreading:
+            if argsCode != "":
+              argsCode = argsCode & ", "
+            argsCode = argsCode & "..." & $x
+            spreading = false
+          else:
+            if x.kind == crDataSymbol and x.symbolVal == "&":
+              spreading = true
+              continue
+            if argsCode != "":
+              argsCode = argsCode & ", "
+            argsCode = argsCode & ($x).escapeVar
+        content = content & fmt"{cLine}let {def.escapeVar} = ({argsCode}) => {cCurlyL}{cLine}{f.fnCode.toJsCode}{cCurlyR}{cLine}"
       of crDataThunk:
-        echo " thunk: ", def
+        content = content & fmt"{cLine}let {def.escapeVar} = {f.thunkCode[].toJsCode};{cLine}"
+      of crDataMacro:
+        # macro should be handled during compilation
+        discard
+      of crDataSyntax:
+        # should he handled inside compiler
+        discard
       else:
         echo " ...well ", $f.kind
+    writeFile jsFilePath, content
+    echo "Emitted mjs file: ", jsFilePath

--- a/src/calcit_runner/eval_util.nim
+++ b/src/calcit_runner/eval_util.nim
@@ -83,3 +83,15 @@ proc evaluteMacroData*(macroValue: CirruData, args: seq[CirruData], interpret: F
     raiseEvalError("expects a list or a liternal from defmacro", quoted)
 
   return quoted
+
+# code of functions and macros
+proc isADefinition*(code: CirruData): bool =
+  if code.kind != crDataList:
+    return false
+  if code.listVal.len == 0:
+    raiseEvalError("expects some code other than empty", code)
+  if code.listVal[0].kind == crDataSymbol:
+    let text = code.listVal[0].symbolVal
+    if text == "defn" or text == "defmacro":
+      return true
+  return false

--- a/src/calcit_runner/event_loop.nim
+++ b/src/calcit_runner/event_loop.nim
@@ -1,0 +1,68 @@
+
+import os
+import options
+
+import ternary_tree
+
+import ./types
+import ./errors
+import ./eval_util
+import ./evaluate
+
+type EventTaskParams* = tuple[id: int, params: seq[CirruData]]
+type EventTaskCallback* = tuple[ns: string, cb: CirruData]
+
+var eventsChan*: Channel[EventTaskParams]
+
+# TODO open by default might be bad
+eventsChan.open()
+
+# TODO hold memory for 20 items, corresponding to threads below
+var eventCalls: array[0..19, Option[EventTaskCallback]]
+
+proc addTask*(f: CirruData, ns: string): int =
+  if f.kind != crDataFn and f.kind != crDataProc:
+    raiseEvalError("expects a function callback for task", f)
+
+  var taskId = -1
+  for idx in 0..<20:
+    if eventCalls[idx].isNone:
+      taskId = idx
+      break
+  if taskId == -1:
+    raiseEvalError("20 threads max, all occupied", CirruData(kind: crDataNil))
+
+  eventCalls[taskId] = some((ns, f))
+
+  return taskId
+
+proc finishTask*(taskId: int, args: seq[CirruData]): void =
+  if taskId < 0 or taskId >= 20:
+    raiseEvalError("no callback found", CirruData(kind: crDataString, stringVal: $taskId))
+  let maybeTask = eventCalls[taskId]
+  if maybeTask.isNone:
+    raiseEvalError("no callback found", CirruData(kind: crDataString, stringVal: $taskId))
+  let task = maybeTask.get
+  let f = task.cb
+  if f.kind != crDataFn and f.kind != crDataProc:
+    raiseEvalError("expects a function callback for task", f)
+
+  discard evaluteFnData(f, args, interpret, task.ns)
+  eventCalls[taskId] = none(EventTaskCallback)
+
+type TimeoutTaskOptions = tuple[id: int, duration: int]
+proc timeoutCallTask*(info: TimeoutTaskOptions) {.thread.} =
+  sleep info.duration
+
+  eventsChan.send((info.id, @[]))
+
+# TODO hold memory for 20 threads, could be too small
+var eventLoopTaskList: array[0..19, Thread[TimeoutTaskOptions]]
+
+proc setupTimeoutTask*(duration: int, f: CirruData, ns: string): int =
+  let taskId = addTask(f, ns)
+
+  let info: TimeoutTaskOptions = (taskId, duration)
+  createThread(eventLoopTaskList[taskId], timeoutCallTask, info)
+
+  return taskId

--- a/src/calcit_runner/event_loop.nim
+++ b/src/calcit_runner/event_loop.nim
@@ -1,6 +1,6 @@
 
 import os
-import options
+import tables
 
 import ternary_tree
 
@@ -11,58 +11,53 @@ import ./evaluate
 
 type EventTaskParams* = tuple[id: int, params: seq[CirruData]]
 type EventTaskCallback* = tuple[ns: string, cb: CirruData]
+type TimeoutTaskOptions = tuple[id: int, duration: int]
 
 var eventsChan*: Channel[EventTaskParams]
 
-# TODO open by default might be bad
+# open by default, may not be best choice
 eventsChan.open()
 
-# TODO hold memory for 20 items, corresponding to threads below
-var eventCalls: array[0..19, Option[EventTaskCallback]]
+var eventCalls: Table[int, EventTaskCallback]
+var eventCallerId = 0
+
+# hold memories for threads, also creates dynamically
+# might cause "illegal storage access" when threads are too many. temp fix is --gc:orc
+var eventLoopTasks: Table[int, Thread[TimeoutTaskOptions]]
 
 proc addTask*(f: CirruData, ns: string): int =
   if f.kind != crDataFn and f.kind != crDataProc:
     raiseEvalError("expects a function callback for task", f)
 
-  var taskId = -1
-  for idx in 0..<20:
-    if eventCalls[idx].isNone:
-      taskId = idx
-      break
-  if taskId == -1:
-    raiseEvalError("20 threads max, all occupied", CirruData(kind: crDataNil))
+  var taskId = eventCallerId
+  eventCallerId = eventCallerId + 1
 
-  eventCalls[taskId] = some((ns, f))
+  eventCalls[taskId] = (ns, f)
 
   return taskId
 
 proc finishTask*(taskId: int, args: seq[CirruData]): void =
-  if taskId < 0 or taskId >= 20:
+  if eventCalls.contains(taskId).not:
     raiseEvalError("no callback found", CirruData(kind: crDataString, stringVal: $taskId))
-  let maybeTask = eventCalls[taskId]
-  if maybeTask.isNone:
-    raiseEvalError("no callback found", CirruData(kind: crDataString, stringVal: $taskId))
-  let task = maybeTask.get
+  let task = eventCalls[taskId]
   let f = task.cb
   if f.kind != crDataFn and f.kind != crDataProc:
     raiseEvalError("expects a function callback for task", f)
 
   discard evaluteFnData(f, args, interpret, task.ns)
-  eventCalls[taskId] = none(EventTaskCallback)
+  eventCalls.del(taskId)
 
-type TimeoutTaskOptions = tuple[id: int, duration: int]
 proc timeoutCallTask*(info: TimeoutTaskOptions) {.thread.} =
   sleep info.duration
 
   eventsChan.send((info.id, @[]))
 
-# TODO hold memory for 20 threads, could be too small
-var eventLoopTaskList: array[0..19, Thread[TimeoutTaskOptions]]
-
 proc setupTimeoutTask*(duration: int, f: CirruData, ns: string): int =
   let taskId = addTask(f, ns)
+  var mem: Thread[TimeoutTaskOptions]
+  eventLoopTasks[taskId] = mem
 
   let info: TimeoutTaskOptions = (taskId, duration)
-  createThread(eventLoopTaskList[taskId], timeoutCallTask, info)
+  createThread(eventLoopTasks[taskId], timeoutCallTask, info)
 
   return taskId

--- a/src/calcit_runner/version.nim
+++ b/src/calcit_runner/version.nim
@@ -1,2 +1,2 @@
 
-let commandLineVersion* = "0.2.3"
+let commandLineVersion* = "0.2.4"

--- a/src/calcit_runner/version.nim
+++ b/src/calcit_runner/version.nim
@@ -1,2 +1,2 @@
 
-let commandLineVersion* = "0.2.5"
+let commandLineVersion* = "0.2.6"

--- a/src/calcit_runner/version.nim
+++ b/src/calcit_runner/version.nim
@@ -1,2 +1,2 @@
 
-let commandLineVersion* = "0.2.4"
+let commandLineVersion* = "0.2.5"

--- a/src/calcit_runner/watcher.nim
+++ b/src/calcit_runner/watcher.nim
@@ -5,7 +5,6 @@ import libfswatch/fswatch
 var watchingChan*: Channel[string]
 
 proc watchingTask*(incrementFile: string) {.thread.} =
-  echo "watching..."
   let fileChangeCb = proc (event: fsw_cevent, event_num: cuint): void =
     watchingChan.send("changed")
 

--- a/src/calcit_runner/watcher.nim
+++ b/src/calcit_runner/watcher.nim
@@ -5,6 +5,7 @@ import libfswatch/fswatch
 var watchingChan*: Channel[string]
 
 proc watchingTask*(incrementFile: string) {.thread.} =
+  echo "watching..."
   let fileChangeCb = proc (event: fsw_cevent, event_num: cuint): void =
     watchingChan.send("changed")
 

--- a/src/cr.nim
+++ b/src/cr.nim
@@ -14,6 +14,7 @@ import ./calcit_runner/watcher
 import ./calcit_runner/errors
 import ./calcit_runner/version
 import ./calcit_runner/event_loop
+import ./calcit_runner/emit_js
 
 var runOnce = false
 var evalOnce = false
@@ -87,6 +88,8 @@ while true:
         dimEcho "Runner: watching mode disabled."
     if cliArgs.key == "init-fn" and cliArgs.val != "":
       initFn = some(cliArgs.val)
+    if cliArgs.key == "emit-js":
+      jsMode = true
   of cmdArgument:
     snapshotFile = cliArgs.key
     incrementFile = cliArgs.key.replace("compact", ".compact-inc")

--- a/src/cr.nim
+++ b/src/cr.nim
@@ -13,6 +13,7 @@ import ./calcit_runner/canvas
 import ./calcit_runner/watcher
 import ./calcit_runner/errors
 import ./calcit_runner/version
+import ./calcit_runner/event_loop
 
 var runOnce = false
 var evalOnce = false
@@ -59,7 +60,12 @@ proc watchFile(snapshotFile: string, incrementFile: string): void =
           runEventListener(event)
     )
 
-    sleep(180)
+    let triedEvent = eventsChan.tryRecv()
+    if triedEvent.dataAvailable:
+      let taskParams = triedEvent.msg
+      finishTask(taskParams.id, taskParams.params)
+
+    sleep(90)
 
 var cliArgs = initOptParser(commandLineParams())
 var snapshotFile = "compact.cirru"

--- a/tests/snapshots/test.cirru
+++ b/tests/snapshots/test.cirru
@@ -17,9 +17,6 @@
             assert "|keyword function" $ =
               :a ({} (:a 1))
               , 1
-            assert "|keyword used at nil" $ =
-              :a nil
-              , nil
             &let
               base $ {} (:a 1)
               assert= 1 $ base :a


### PR DESCRIPTION
试验了用 threads + channel 来实现 event loop 的功能, 试验的 API 是 `timeout-call` 定时器. 现在定时器是在另一个 thread 当中运行的, 也就意味着一个定时器就需要占用一个 thread. 还没有考虑清楚针对网络操作的扩展性...

定时器本身可以用内部的 event loop 替换, 但是先不管, 网络请求是无法用这类方案替换的. Nim 的 threads 抽象似乎还是比较接近底层的, 为了安全性和易用性做了封装, 没有 green threads 之类的强大功能, 了解不够...

目前 Nim 默认用 refc 来做 GC, 当前实现的报错 cb 来做后续回调的写法可能导致非法访问已经 GC 的内存, 线程过多时可能触发. 暂时可以用 `--gc:orc` 绕过, 具体原理挺复杂, 没有定位清楚 https://nim-lang.org/blog/2020/10/15/introduction-to-arc-orc-in-nim.html .
