### PR TITLE
handled some issues related to js generating

### DIFF
--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -13,9 +13,9 @@ binDir        = "out/"
 
 requires "nim >= 1.2.8"
 requires "libfswatch"
-requires "https://github.com/Cirru/cirru-edn.nim#v0.4.0"
+requires "https://github.com/Cirru/cirru-edn.nim#v0.4.2"
 requires "ternary_tree >= 0.1.28"
-requires "https://github.com/calcit-lang/edn-paint#v0.2.4"
+requires "https://github.com/calcit-lang/edn-paint#v0.2.6"
 requires "nanoid"
 requires "https://github.com/dual-balanced-ternary/dual-balanced-ternary.nim#v0.0.4"
 
@@ -44,4 +44,4 @@ task jsgen, "try generating js":
   exec "nim compile --verbosity:0 --hints:off --threads:on -r src/cr --emit-js example/compact.cirru --once"
 
 task jslib, "generating js core lib core from Nim":
-  exec "nim js -d:release -o:js-out/procs.js src/calcit_runner/js_procs.nim"
+  exec "nim js -d:release -o:js-out/calcit.procs.mjs src/calcit_runner/js_procs.nim"

--- a/src/calcit_runner/core_func.nim
+++ b/src/calcit_runner/core_func.nim
@@ -635,7 +635,7 @@ proc nativeTurnSymbol(args: seq[CirruData], interpret: FnInterpret, scope: Cirru
   let x = args[0]
   case x.kind
   of crDataKeyword:
-    return CirruData(kind: crDataSymbol, symbolVal: x.keywordVal[], ns: ns, dynamic: true)
+    return CirruData(kind: crDataSymbol, symbolVal: x.keywordVal, ns: ns, dynamic: true)
   of crDataString:
     return CirruData(kind: crDataSymbol, symbolVal: x.stringVal, ns: ns, dynamic: true)
   of crDataSymbol:
@@ -649,7 +649,7 @@ proc nativeTurnString(args: seq[CirruData], interpret: FnInterpret, scope: Cirru
   let x = args[0]
   case x.kind
   of crDataKeyword:
-    return CirruData(kind: crDataString, stringVal: x.keywordVal[])
+    return CirruData(kind: crDataString, stringVal: x.keywordVal)
   of crDataString:
     return x
   of crDataSymbol:
@@ -973,7 +973,7 @@ proc nativeAddWatch(args: seq[CirruData], interpret: FnInterpret, scope: CirruDa
   if k.kind != crDataKeyword: raiseEvalError("expects an keyword for add-watch", args)
   let f = args[2]
   if f.kind != crDataFn and a.kind != crDataProc: raiseEvalError("expects an function for add-watch", args)
-  addAtomWatcher(a.atomNs, a.atomDef, k.keywordVal[], f)
+  addAtomWatcher(a.atomNs, a.atomDef, k.keywordVal, f)
 
 proc nativeRemoveWatch(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
   if args.len != 2: raiseEvalError("reset! expects 2 arguments", args)
@@ -981,7 +981,7 @@ proc nativeRemoveWatch(args: seq[CirruData], interpret: FnInterpret, scope: Cirr
   if a.kind != crDataAtom: raiseEvalError("expects an atom to reset!", args)
   let k = args[1]
   if k.kind != crDataKeyword: raiseEvalError("expects an keyword for add-watch", args)
-  removeAtomWatcher(a.atomNs, a.atomDef, k.keywordVal[])
+  removeAtomWatcher(a.atomNs, a.atomDef, k.keywordVal)
 
 proc nativeSubstr(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
   if args.len < 2: raiseEvalError("substr expects 2~3 arguments", args)

--- a/src/calcit_runner/js_procs.nim
+++ b/src/calcit_runner/js_procs.nim
@@ -1,22 +1,46 @@
 
 import math
+import sets
+import sequtils
+import strutils
+
 import ternary_tree
 
 import dual_balanced_ternary
 
 import ./types
 import ./errors
+import ./data
 
-proc count*(args: seq[CirruData]): int {.exportc.} =
-  return 1
+# TODO staled feature: compiling to js
+# Nim supports js backend, however, Nim is a low-level language.
+# some libs used in Nim does not fit js, this CLI has this problem.
+# just in theory, compile those functions to `calcit.procs.js`,
+# and code emitted from `emit_js.nim` could run.
 
-proc nativeDivide(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData {.exportc.} =
-  if args.len != 2: raiseEvalError("Expected 2 arguments in native divide", args)
-  let a = args[0]
-  let b = args[1]
+proc nativePrint(args: seq[CirruData]): CirruData {.exportc: "print".} =
+  echo args.map(`$`).join(" ")
+  return CirruData(kind: crDataNil)
+
+proc nativeCount(a: CirruData): CirruData {.exportc: "count".} =
+  case a.kind
+  of crDataNil:
+    return CirruData(kind: crDataNumber, numberVal: 0.0)
+  of crDataList:
+    return CirruData(kind: crDataNumber, numberVal: a.len.float)
+  of crDataMap:
+    return CirruData(kind: crDataNumber, numberVal: a.len.float)
+  of crDataSet:
+    return CirruData(kind: crDataNumber, numberVal: a.setVal.len.float)
+  of crDataString:
+    return CirruData(kind: crDataNumber, numberVal: a.stringVal.len.float)
+  else:
+    raiseEvalError("Cannot count data", a)
+
+proc nativeDivide(a, b: CirruData): CirruData {.exportc: "_SLSH_".} =
   if a.kind == crDataTernary and b.kind == crDataTernary:
     return CirruData(kind: crDataTernary, ternaryVal: a.ternaryVal / b.ternaryVal)
   if a.kind != crDataNumber: raiseEvalError("Required number for divide", a)
   if b.kind != crDataNumber: raiseEvalError("Required number for divide", b)
-  if b.numberVal == 0.0: raiseEvalError("Cannot divide by 0", args)
+  if b.numberVal == 0.0: raiseEvalError("Cannot divide by 0", @[a, b])
   return CirruData(kind: crDataNumber, numberVal: a.numberVal / b.numberVal)

--- a/src/calcit_runner/loader.nim
+++ b/src/calcit_runner/loader.nim
@@ -217,7 +217,7 @@ proc extractNsInfo*(exprNode: CirruData): Table[string, ImportInfo] =
   if requireArea.kind != crDataList:
     raiseEvalError("Expects require list in ns form", exprNode)
   let requireNode = requireArea[0]
-  let nodeText = requireNode.keywordVal[]
+  let nodeText = requireNode.keywordVal
   if not requireNode.isKeyword or nodeText != "require":
     raiseEvalError("Expects :require", requireNode)
   let requireList = requireArea[1..^1]
@@ -236,7 +236,7 @@ proc extractNsInfo*(exprNode: CirruData): Table[string, ImportInfo] =
     let importOp = importDec[2]
     if not importOp.isKeyword:
       raiseEvalError("Expects import op in keyword", importOp)
-    case importOp.keywordVal[]:
+    case importOp.keywordVal:
     of "as":
       let aliasName = importDec[3]
       if aliasName.kind != crDataSymbol:

--- a/src/calcit_runner/str_util.nim
+++ b/src/calcit_runner/str_util.nim
@@ -1,0 +1,92 @@
+
+proc isDigit(c: char): bool =
+  let n = ord(c)
+  # ascii table https://tool.oschina.net/commons?type=4
+  n >= 48 and n <= 57
+
+proc isLetter(c: char): bool =
+  let n = ord(c)
+  if n >= 65 and n <= 90:
+    return true
+  if n >= 97 and n <= 122:
+    return true
+  return false
+
+proc matchesFloat*(xs: string): bool =
+  if xs.len == 0:
+    return false
+
+  var buffer = xs
+  if xs[0] == '-':
+    buffer = xs[1..^1]
+
+  if buffer.len == 0:
+    return false
+
+  var countDigits = 0
+  var countDot = 0
+  for x in buffer:
+    if x.isDigit():
+      countDigits += 1
+    elif x == '.':
+      countDot += 1
+    else:
+      return false
+
+  if countDigits < 1:
+    return false
+  if countDot > 1:
+    return false
+
+  return true
+
+proc matchesTernary*(xs: string): bool =
+  if xs.len == 0:
+    return false
+
+  if xs[0] != '&':
+    return false
+
+  var buffer = xs[1..^1]
+
+  if buffer.len == 0:
+    return false
+
+  var countDigits = 0
+  var countDot = 0
+  for x in buffer:
+    if x.isDigit():
+      if x == '0':
+        # ternary does not use '0'
+        return false
+      countDigits += 1
+    elif x == '.':
+      countDot += 1
+    else:
+      return false
+
+  if countDigits < 1:
+    return false
+  if countDot > 1:
+    return false
+
+  return true
+
+proc matchesSimpleVar*(xs: string): bool =
+  if xs.len == 0:
+    return false
+  for x in xs:
+    if x.isLetter():
+      continue
+    elif x.isDigit():
+      continue
+    elif x == '-':
+      continue
+    elif x == '!':
+      continue
+    elif x == '*':
+      continue
+    elif x == '?':
+      continue
+    return false
+  return true

--- a/src/calcit_runner/to_json.nim
+++ b/src/calcit_runner/to_json.nim
@@ -24,9 +24,9 @@ proc toJson*(x: CirruData, keywordColon: bool = false): JsonNode =
     return JsonNode(kind: JString, str: x.stringVal)
   of crDataKeyword:
     if keywordColon:
-      return JsonNode(kind: JString, str: ":" & x.keywordVal[])
+      return JsonNode(kind: JString, str: ":" & x.keywordVal)
     else:
-      return JsonNode(kind: JString, str: x.keywordVal[])
+      return JsonNode(kind: JString, str: x.keywordVal)
   of crDataList:
     var elems: seq[JsonNode] = @[]
     for i, child in x.listVal:
@@ -45,9 +45,9 @@ proc toJson*(x: CirruData, keywordColon: bool = false): JsonNode =
         fields[k.stringVal] = toJson(v, keywordColon)
       of crDataKeyword:
         if keywordColon:
-          fields[":" & k.keywordVal[]] = toJson(v, keywordColon)
+          fields[":" & k.keywordVal] = toJson(v, keywordColon)
         else:
-          fields[k.keywordVal[]] = toJson(v, keywordColon)
+          fields[k.keywordVal] = toJson(v, keywordColon)
       else:
         raise newException(ValueError, "required string keys in JObject")
     return JsonNode(kind: JObject, fields: fields)
@@ -109,7 +109,7 @@ proc toCirruNode*(x: CirruData): CirruNode =
   of crDataString:
     return CirruNode(kind: cirruString, text: "|" & x.stringVal)
   of crDataKeyword:
-    return CirruNode(kind: cirruString, text: ":" & x.keywordVal[])
+    return CirruNode(kind: cirruString, text: ":" & x.keywordVal)
   of crDataList:
     var elems: DoublyLinkedList[CirruNode]
     for child in x.listVal:
@@ -138,7 +138,7 @@ proc toEdn*(x: CirruData): CirruEdnValue =
   of crDataString:
     return CirruEdnValue(kind: crEdnString, stringVal: x.stringVal)
   of crDataKeyword:
-    return CirruEdnValue(kind: crEdnKeyword, keywordVal: x.keywordVal[])
+    return CirruEdnValue(kind: crEdnKeyword, keywordVal: x.keywordVal)
   of crDataList:
     var elems: seq[CirruEdnValue] = @[]
     for i, child in x.listVal:


### PR DESCRIPTION
`re` module does not fit js, so removed from some of dependencies.

`ref string` used `c.keywordVal[]` breaks compiler, so refactored to bare string.

At least js code can be generated now. Still lots of things to handle, especially for core procs that are provided in `calcit.core`.
