### PR TITLE
base functions and syntax for js interop

### DIFF
--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -1,7 +1,7 @@
 
 # Package
 
-version       = "0.2.10"
+version       = "0.2.11"
 author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"

--- a/src/calcit_runner/core_func.nim
+++ b/src/calcit_runner/core_func.nim
@@ -180,6 +180,16 @@ proc nativeRest(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataSc
     if a.len == 0:
       return CirruData(kind: crDataNil)
     return CirruData(kind: crDataList, listVal: a.listVal.rest)
+  of crDataSet:
+    if a.setVal.len == 0:
+      return CirruData(kind: crDataNil)
+    var item: CirruData
+    for x in a.setVal:
+      item = x
+      break
+    var newSet: HashSet[CirruData] = a.setVal
+    newSet.excl(item)
+    return CirruData(kind: crDataSet, setVal: newSet)
   else:
     raiseEvalError(fmt"Cannot rest from data of this type: {a.kind}", a)
 
@@ -344,6 +354,12 @@ proc nativeFirst(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataS
       return CirruData(kind: crDataNil)
     else:
       return CirruData(kind: crDataString, stringVal: base.stringVal.runeAtPos(0).toUTF8())
+  of crDataSet:
+    if base.setVal.len == 0:
+      return CirruData(kind: crDataNil)
+    else:
+      for item in base.setVal:
+        return item # just return a item with a reproduceable method
   else:
     raiseEvalError("first requires a list but got " & $base.kind, args)
 

--- a/src/calcit_runner/emit_js.nim
+++ b/src/calcit_runner/emit_js.nim
@@ -150,7 +150,7 @@ proc toJsCode(xs: CirruData, ns: string, localDefs: HashSet[string]): string =
             result = result & x.toJsCode(ns, scopedDefs) & ";\n"
         return result & "})()"
       of ";":
-        return "/* " & $CirruData(kind: crDataList, listVal: body) & " */"
+        return "(/* " & $CirruData(kind: crDataList, listVal: body) & " */ null)"
       of "do":
         result = "(()=>{" & cLine
         for idx, x in body:

--- a/src/calcit_runner/emit_js.nim
+++ b/src/calcit_runner/emit_js.nim
@@ -11,6 +11,7 @@ import ternary_tree
 
 import ./types
 import ./errors
+import ./str_util
 
 const cLine = "\n"
 const cCurlyL = "{"
@@ -35,7 +36,11 @@ proc escapeVar(name: string): string =
       raiseEvalError("Expected format of ns/def", CirruData(kind: crDataString, stringVal: name))
     let nsPart = pieces[0]
     let defPart = pieces[1]
-    return nsPart.escapeVar() & "." & defPart.escapeVar()
+    if nsPart == "js":
+      return defPart
+    else:
+      return nsPart.escapeVar() & "." & defPart.escapeVar()
+
   result = name
   .replace("-", "_DASH_")
   .replace("?", "_QUES_")
@@ -58,6 +63,7 @@ proc escapeVar(name: string): string =
   .replace(";", "_SCOL_")
   .replace("#", "_SHA_")
   .replace("\\", "_BSL_")
+  .replace(".", "_DOT_")
   if result == "if": result = "_IF_"
   if result == "do": result = "_DO_"
   if result == "else": result = "_ELSE_"
@@ -66,6 +72,7 @@ proc escapeVar(name: string): string =
 
 # handle recursion
 proc genJsFunc(name: string, args: TernaryTreeList[CirruData], body: seq[CirruData], ns: string, exported: bool, outerDefs: HashSet[string]): string
+proc genArgsCode(body: TernaryTreeList[CirruData], ns: string, localDefs: HashSet[string]): string
 
 # based on https://github.com/nim-lang/Nim/blob/version-1-4/lib/pure/strutils.nim#L2322
 # strutils.escape turns Chinese into longer something "\xE6\xB1\x89",
@@ -195,22 +202,41 @@ proc toJsCode(xs: CirruData, ns: string, localDefs: HashSet[string]): string =
           raiseEvalError("expected a single argument", body.toSeq())
         let message: string = $body[0]
         return fmt"(()=> {cCurlyL} throw new Error({message.escape}) {cCurlyR})() "
+
       else:
-        discard
-    var argsCode = ""
-    var spreading = false
-    for x in body:
-      if x.kind == crDataSymbol and x.symbolVal == "&":
-        spreading = true
-      else:
-        if argsCode != "":
-          argsCode = argsCode & ", "
-        if spreading:
-          argsCode = argsCode & "..."
-        argsCode = argsCode & x.toJsCode(ns, localDefs)
-    result = result & head.toJsCode(ns, localDefs) & "(" & argsCode & ")"
+        let token = head.symbolVal
+        if token.len > 2 and token[0..1] == ".-" and token[2..^1].matchesJsVar():
+          let name = token[2..^1]
+          if xs.listVal.len != 2:
+            raiseEvalError("property accessor takes only 1 argument", xs)
+          let obj = xs.listVal[1]
+          return obj.toJsCode(ns, localDefs) & "." & name
+        elif token.len > 1 and token[0] == '.' and token[1..^1].matchesJsVar():
+          let name = token[1..^1]
+          if xs.listVal.len < 2:
+            raiseEvalError("property accessor takes at least 1 argument", xs)
+          let obj = xs.listVal[1]
+          let args = xs.listVal.slice(2, xs.listVal.len)
+          let argsCode = genArgsCode(args, ns, localDefs)
+          return obj.toJsCode(ns, localDefs) & "." & name & "(" & argsCode & ")"
+        else:
+          discard
+    var argsCode = genArgsCode(body, ns, localDefs)
+    return head.toJsCode(ns, localDefs) & "(" & argsCode & ")"
   else:
-    echo "[WARNING] unknown kind to gen js code: ", xs.kind
+    raiseEvalError("[WARNING] unknown kind to gen js code: " & $xs.kind, xs)
+
+proc genArgsCode(body: TernaryTreeList[CirruData], ns: string, localDefs: HashSet[string]): string =
+  var spreading = false
+  for x in body:
+    if x.kind == crDataSymbol and x.symbolVal == "&":
+      spreading = true
+    else:
+      if result != "":
+        result = result & ", "
+      if spreading:
+        result = result & "..."
+      result = result & x.toJsCode(ns, localDefs)
 
 proc toJsCode(xs: seq[CirruData], ns: string, localDefs: HashSet[string]): string =
   for idx, x in xs:
@@ -285,12 +311,12 @@ proc emitJs*(programData: Table[string, ProgramFile], entryNs, entryDef: string)
     if file.ns.isSome():
       let importsInfo = file.ns.get()
       for importName, importRule in importsInfo:
-        let importTarget = importRule.ns.toJsFileName()
+        let importTarget = if importRule.nsInStr: importRule.ns else: "./" & importRule.ns.toJsFileName()
         case importRule.kind
         of importDef:
-          content = content & fmt"{cLine}import {cCurlyL}{importName.escapeVar}{cCurlyR} from {cDbQuote}./{importTarget}{cDbQuote};{cLine}"
+          content = content & fmt"{cLine}import {cCurlyL}{importName.escapeVar}{cCurlyR} from {cDbQuote}{importTarget}{cDbQuote};{cLine}"
         of importNs:
-          content = content & fmt"{cLine}import * as {importName.escapeVar} from {cDbQuote}./{importTarget}{cDbQuote};{cLine}"
+          content = content & fmt"{cLine}import * as {importName.escapeVar} from {cDbQuote}{importTarget}{cDbQuote};{cLine}"
     else:
       # echo "[WARNING] no imports information for ", ns
       discard

--- a/src/calcit_runner/str_util.nim
+++ b/src/calcit_runner/str_util.nim
@@ -90,3 +90,19 @@ proc matchesSimpleVar*(xs: string): bool =
       continue
     return false
   return true
+
+proc matchesJsVar*(xs: string): bool =
+  if xs.len == 0:
+    return false
+  for idx, x in xs:
+    if x.isLetter():
+      continue
+    if idx > 0:
+      if x.isDigit():
+        continue
+      elif x == '_':
+        continue
+      elif x == '$':
+        continue
+    return false
+  return true

--- a/src/calcit_runner/types.nim
+++ b/src/calcit_runner/types.nim
@@ -19,6 +19,7 @@ type ImportKind* = enum
   importNs, importDef
 type ImportInfo* = object
   ns*: string
+  nsInStr*: bool # js modules uses a string based path
   case kind*: ImportKind
   of importNs:
     discard
@@ -52,7 +53,7 @@ type
 
   FnInData* = proc(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData
 
-  ResolvedPath* = tuple[ns: string, def: string]
+  ResolvedPath* = tuple[ns: string, def: string, nsInStr: bool]
 
   CirruData* = object
     case kind*: CirruDataKind

--- a/src/calcit_runner/version.nim
+++ b/src/calcit_runner/version.nim
@@ -1,2 +1,2 @@
 
-let commandLineVersion* = "0.2.10"
+let commandLineVersion* = "0.2.11"

--- a/src/includes/calcit.procs.ts
+++ b/src/includes/calcit.procs.ts
@@ -427,6 +427,9 @@ export let empty_QUES_ = (xs: CrDataValue): boolean => {
   if (xs instanceof Map) {
     return xs.size === 0;
   }
+  if (xs instanceof Set) {
+    return xs.size === 0;
+  }
   if (xs == null) {
     return true;
   }
@@ -470,6 +473,13 @@ export let first = (xs: CrDataValue): CrDataValue => {
   if (typeof xs === "string") {
     return xs[0];
   }
+  if (xs instanceof Set) {
+    if (xs.size === 0) {
+      return null;
+    }
+    let it = xs.values();
+    return it.next().value;
+  }
   throw new Error("Expects something sequential");
 };
 
@@ -493,6 +503,16 @@ export let rest = (xs: CrDataValue): CrDataValue => {
   }
   if (typeof xs === "string") {
     return xs.substr(1);
+  }
+  if (xs instanceof Set) {
+    if (xs.size == 0) {
+      return null;
+    }
+    let it = xs.values();
+    let x0 = it.next().value;
+    let ys = cloneSet(xs);
+    ys.delete(x0);
+    return ys;
   }
   throw new Error("Expects something sequential");
 };

--- a/src/includes/calcit.procs.ts
+++ b/src/includes/calcit.procs.ts
@@ -23,9 +23,11 @@ class CrDataRecur {
 
 class CrDataAtom {
   value: CrDataValue;
+  path: string;
   listeners: Map<CrDataValue, CrDataFn>;
-  constructor(x: CrDataValue) {
+  constructor(x: CrDataValue, path: string) {
     this.value = x;
+    this.path = path;
     this.listeners = new Map();
   }
 }
@@ -58,7 +60,7 @@ export let kwd = (content: string) => {
   }
 };
 
-var atomsRegistry = new Map();
+var atomsRegistry = new Map<string, CrDataAtom>();
 
 export let type_DASH_of = (x: any): CrDataKeyword => {
   if (typeof x === "string") {
@@ -143,13 +145,21 @@ export let _AND__MAP_ = (
 };
 
 export let defatom = (path: string, x: CrDataValue): CrDataValue => {
-  let v = new CrDataAtom(x);
+  let v = new CrDataAtom(x, path);
   atomsRegistry.set(path, v);
   return v;
 };
 
+export let peekDefatom = (path: string): CrDataAtom => {
+  return atomsRegistry.get(path);
+};
+
 export let deref = (x: CrDataAtom): CrDataValue => {
-  return x.value;
+  let a = atomsRegistry.get(x.path);
+  if (!(a instanceof CrDataAtom)) {
+    console.warn("Can not find atom:", x);
+  }
+  return a.value;
 };
 
 export let foldl = (

--- a/src/includes/calcit.procs.ts
+++ b/src/includes/calcit.procs.ts
@@ -985,6 +985,14 @@ export let aset = (x: any, name: string, v: any): any => {
   return (x[name] = v);
 };
 
+export let get_DASH_env = (name: string): string => {
+  if ((globalThis as any)["process"] != null) {
+    // only available for Node.js
+    return (globalThis as any)["process"].env[name];
+  }
+  return null;
+};
+
 // TODO not handled correct in generated js
 export let reduce = foldl;
 export let conj = append;

--- a/src/includes/calcit.procs.ts
+++ b/src/includes/calcit.procs.ts
@@ -958,6 +958,13 @@ export let set_DASH__GT_list = (x: Set<CrDataValue>): CrDataValue[] => {
   return result;
 };
 
+export let aget = (x: any, name: string): any => {
+  return x[name];
+};
+export let aset = (x: any, name: string, v: any): any => {
+  return (x[name] = v);
+};
+
 // TODO not handled correct in generated js
 export let reduce = foldl;
 export let conj = append;

--- a/tests/snapshots/test-js.cirru
+++ b/tests/snapshots/test-js.cirru
@@ -1,0 +1,43 @@
+
+{} (:package |test-js)
+  :configs $ {} (:init-fn |test-js.main/main!) (:reload-fn |test-js.main/reload!)
+  :files $ {}
+    |test-js.main $ {}
+      :ns $ quote
+        ns test-js.main $ :require
+          [] |os :as os
+      :defs $ {}
+
+        |log-title $ quote
+          defn log-title (title)
+            echo
+            echo title
+            echo
+
+        |test-js $ quote
+          fn ()
+            js/console.log $ js/Math.pow 4 4
+            js/console.log $ * js/Math.PI 2
+            when
+              = |number (js/typeof 1)
+              js/console.log "|is a Number"
+
+            .log js/console |demo
+            js/console.log $ .-PI js/Math
+
+            js/console.log $ aget js/Math |PI
+            let
+                a js/{}
+              aset a |name |demo
+              js/console.log a
+            js/console.log $ os/arch
+
+        |main! $ quote
+          defn main! ()
+            log-title "|Testing json"
+            test-js
+
+            do true
+
+      :proc $ quote ()
+      :configs $ {} (:extension nil)

--- a/tests/snapshots/test-recursion.cirru
+++ b/tests/snapshots/test-recursion.cirru
@@ -15,7 +15,7 @@
 
         |hole-series $ quote
           defn hole-series (x)
-            if (&<= x 0) (raise-at "\"unexpected small number" x)
+            if (&<= x 0) (raise "\"unexpected small number")
               if (&= x 1) (, 0)
                 if (&= x 2) (, 1)
                   let

--- a/tests/snapshots/test-set.cirru
+++ b/tests/snapshots/test-set.cirru
@@ -39,6 +39,17 @@
               assert-detect list? v
               assert= 3 $ count v
 
+            assert=
+              map
+                fn (x) (inc x)
+                #{} 1 2 3
+              #{} 2 3 4
+
+            assert-detect identity
+              every?
+                \ > % 0
+                #{} 1 2 3
+
         |main! $ quote
           defn main! ()
             log-title "|Testing set"

--- a/tests/snapshots/test.cirru
+++ b/tests/snapshots/test.cirru
@@ -4,7 +4,7 @@
     :modules $ [] |./test-cond.cirru |./test-gynienic.cirru |./test-json.cirru
       , |./test-lens.cirru |./test-list.cirru |./test-macro.cirru |./test-map.cirru
       , |./test-math.cirru |./test-recursion.cirru |./test-set.cirru
-      , |./test-string.cirru |./test-ternary.cirru
+      , |./test-string.cirru |./test-ternary.cirru |./test-js.cirru
   :files $ {}
     |app.main $ {}
       :ns $ quote
@@ -21,6 +21,7 @@
           [] test-set.main :as test-set
           [] test-string.main :as test-string
           [] test-ternary.main :as test-ternary
+          [] test-js.main :as test-js
       :defs $ {}
         |log-title $ quote
           defn log-title (title)
@@ -134,6 +135,10 @@
             test-recursion/main!
             test-set/main!
             test-string/main!
+
+            when
+              = :js $ &get-calcit-backend
+              test-js/main!
 
             do true
 


### PR DESCRIPTION
Following syntaxes of ClojureScript,

- string in as ns name to import js module
- special ns `js/` for inserting js code(not variable in this PR)
- `(.-p o)` for reading a property
- `(.m o a)` for callling a method
- `(aget o |p)` for reading a property dynamically
- `(aset o |p v)` for setting a property

here's the demo:

```cirru
{}
  :ns $ quote
    ns test-js.main $ :require
      [] |os :as os
  :defs $ {}

    |test-js $ quote
      fn ()
        js/console.log $ js/Math.pow 4 4
        js/console.log $ * js/Math.PI 2
        when
          = |number (js/typeof 1)
          js/console.log "|is a Number"

        .log js/console |demo
        js/console.log $ .-PI js/Math

        js/console.log $ aget js/Math |PI
        let
            a js/{}
          aset a |name |demo
          js/console.log a
        js/console.log $ os/arch
```

maybe there's still need for adding macros like `(.. a -b (c d))`, which actually could be (-> a .-b (.c d)).
