### PR TITLE
consolidate ns info inside macros and emit implicit import for js

### DIFF
--- a/src/calcit_runner/core_func.nim
+++ b/src/calcit_runner/core_func.nim
@@ -1083,7 +1083,7 @@ proc nativeGensym(args: seq[CirruData], interpret: FnInterpret, scope: CirruData
   genSymIndex = genSymIndex + 1
   case args.len
   of 0:
-    return CirruData(kind: crDataSymbol, ns: ns, dynamic: true, symbolVal: "G__" & $genSymIndex)
+    return CirruData(kind: crDataSymbol, ns: ns, dynamic: false, symbolVal: "G__" & $genSymIndex)
   of 1:
     let item = args[0]
     case item.kind

--- a/src/calcit_runner/core_syntax.nim
+++ b/src/calcit_runner/core_syntax.nim
@@ -139,7 +139,11 @@ proc nativeDefMacro(exprList: seq[CirruData], interpret: FnInterpret, scope: Cir
   if macroName.kind != crDataSymbol: raiseEvalError("Expects macro name a symbol", exprList)
   let argsList = exprList[1]
   if argsList.kind != crDataList: raiseEvalError("Expects macro args to be a list", exprList)
-  return CirruData(kind: crDataMacro, macroName: macroName.symbolVal, macroArgs: argsList.listVal, macroCode: exprList[2..^1])
+  return CirruData(
+    kind: crDataMacro,
+    macroName: macroName.symbolVal, macroNs: ns,
+    macroArgs: argsList.listVal, macroCode: exprList[2..^1]
+  )
 
 proc nativeDefAtom(exprList: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
   if exprList.len != 2:

--- a/src/calcit_runner/evaluate.nim
+++ b/src/calcit_runner/evaluate.nim
@@ -85,6 +85,9 @@ proc interpretSymbol(sym: CirruData, scope: CirruDataScope, ns: string): CirruDa
   raiseEvalError(fmt"Symbol not initialized or recognized: {sym.symbolVal}", sym)
 
 proc interpret*(xs: CirruData, scope: CirruDataScope, ns: string): CirruData =
+  if ns == "":
+    raiseEvalError("Expected non-empty ns", xs)
+
   case xs.kind
   of crDataNil, crDataString, crDataKeyword, crDataNumber, crDataBool, crDataProc, crDataFn, crDataTernary:
     return xs
@@ -177,6 +180,8 @@ proc placeholderFunc(args: seq[CirruData], interpret: FnInterpret, scope: CirruD
   return CirruData(kind: crDataNil)
 
 proc preprocessSymbolByPath*(ns: string, def: string): void =
+  if ns == "":
+    raiseEvalError("Expected non-empty ns at " & def, @[])
   if not programData.hasKey(ns):
     var newFile = ProgramFile()
     programData[ns] = newFile
@@ -256,10 +261,12 @@ proc preprocess*(code: CirruData, localDefs: Hashset[string], ns: string): Cirru
 
         let coreDefs = programData[coreNs].defs
         if coreDefs.contains(sym.symbolVal):
+          sym.ns = coreNs
           sym.resolved = some((coreNs, sym.symbolVal, false))
           return sym
         elif hasNsAndDef(coreNs, sym.symbolVal):
           preprocessSymbolByPath(coreNs, sym.symbolVal)
+          sym.ns = coreNs
           sym.resolved = some((coreNs, sym.symbolVal, false))
           return sym
 

--- a/src/calcit_runner/gen_data.nim
+++ b/src/calcit_runner/gen_data.nim
@@ -24,7 +24,7 @@ proc crData*(x: string, target: string = "string"): CirruData =
   of "keyword":
     CirruData(kind: crDataKeyword, keywordVal: loadKeyword(x))
   of "symbol":
-    CirruData(kind: crDataSymbol, symbolVal: x, ns: "user")
+    CirruData(kind: crDataSymbol, symbolVal: x, ns: "&crData") # use a special mark
   of "string":
     CirruData(kind: crDataString, stringVal: x)
   else:

--- a/src/includes/calcit.procs.ts
+++ b/src/includes/calcit.procs.ts
@@ -7,7 +7,7 @@ class CrDataKeyword {
     return `:${this.value}`;
   }
 }
-class CrDataSymbol {
+export class CrDataSymbol {
   value: string;
   constructor(x: string) {
     this.value = x;


### PR DESCRIPTION
macros generated code that contains definitions from another namespace, and these namespaces are not imported via `ns ... :require ...` form. so an extra way of add importing declaration is required. and during fixing this bug, empty value `""` of ns is not considered invalid for symbols.

should be more robust than previous versions in symbol resolving.
