### PR TITLE
a custom cirru-edn data format for js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 
 out
-js-out
+js-out/
 
 example/.compact-inc.cirru
 .calcit-error.cirru

--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -1,7 +1,7 @@
 
 # Package
 
-version       = "0.2.18"
+version       = "0.2.19"
 author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"

--- a/src/calcit_runner/data.nim
+++ b/src/calcit_runner/data.nim
@@ -201,7 +201,7 @@ proc toCirruData*(xs: CirruNode, ns: string): CirruData =
 proc spreadArgs*(xs: seq[CirruData]): seq[CirruData] =
   var noSpread = true
   for x in xs:
-    if x.kind == crDataSymbol and x.symbolVal == "&":
+    if x.kind == crDataSymbol and x.symbolVal == "&" and not x.dynamic:
       noSpread = false
       break
   if noSpread:
@@ -216,7 +216,7 @@ proc spreadArgs*(xs: seq[CirruData]): seq[CirruData] =
       for y in x:
         args.add y
       spreadMode = false
-    elif x.isSymbol and x.symbolVal == "&":
+    elif x.isSymbol and x.symbolVal == "&" and not x.dynamic:
       spreadMode = true
     else:
       args.add x
@@ -225,7 +225,7 @@ proc spreadArgs*(xs: seq[CirruData]): seq[CirruData] =
 proc spreadFuncArgs*(xs: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): seq[CirruData] =
   var noSpread = true
   for x in xs:
-    if x.kind == crDataSymbol and x.symbolVal == "&":
+    if x.kind == crDataSymbol and x.symbolVal == "&" and not x.dynamic:
       noSpread = false
       break
   if noSpread:
@@ -244,7 +244,7 @@ proc spreadFuncArgs*(xs: seq[CirruData], interpret: FnInterpret, scope: CirruDat
       for y in ys.listVal:
         args.add y
       spreadMode = false
-    elif x.isSymbol and x.symbolVal == "&":
+    elif x.isSymbol and x.symbolVal == "&" and not x.dynamic:
       spreadMode = true
     else:
       args.add interpret(x, scope, ns)

--- a/src/calcit_runner/emit_js.nim
+++ b/src/calcit_runner/emit_js.nim
@@ -103,7 +103,11 @@ proc escapeCirruStr*(s: string): string =
     else: result.add(c)
   result.add('"')
 
-let builtInJsProc = toHashSet(["aget", "aset"])
+let builtInJsProc = toHashSet([
+  "aget", "aset",
+  "extract-cirru-edn",
+  "to-cirru-edn",
+])
 
 proc toJsCode(xs: CirruData, ns: string, localDefs: HashSet[string]): string =
   let varPrefix = if ns == "calcit.core": "" else: "_calcit_."

--- a/src/calcit_runner/preprocess.nim
+++ b/src/calcit_runner/preprocess.nim
@@ -69,9 +69,9 @@ proc processNativeLet*(xs: CirruData, localDefs: Hashset[string], preprocess: Fn
   var bindingBuffer = initTernaryTreeList[CirruData](@[])
 
   if pair.kind != crDataList:
-    raiseEvalError("Expects a list", pair)
+    raiseEvalError("Expects a list in &let", pair)
   if pair.len != 2:
-    raiseEvalError("Expects len =2", pair)
+    raiseEvalError("Expects pair len =2 in &let", pair)
 
   let defName = pair[0]
   let detail = pair[1]

--- a/src/calcit_runner/version.nim
+++ b/src/calcit_runner/version.nim
@@ -1,2 +1,2 @@
 
-let commandLineVersion* = "0.2.18"
+let commandLineVersion* = "0.2.19"

--- a/src/includes/calcit-core.cirru
+++ b/src/includes/calcit-core.cirru
@@ -858,6 +858,37 @@
                       , items
                     ~@ body
 
+        |let[] $ quote
+          defmacro let[] (vars data & body)
+            assert "|expects a list of definitions"
+              and (list? vars)
+                &> (count vars) 0
+                every? symbol? vars
+            let
+                v $ gensym |v
+                defs $ apply-args
+                  [] ([]) vars 0
+                  defn let[]% (acc xs idx)
+                    if (empty? xs) acc
+                      do
+                        when-not
+                          symbol? (first xs)
+                          raise $ str "|Expected symbol for vars: " (first xs)
+                        if (&= (first xs) '&)
+                          do
+                            assert "|expected list spreading" (&= 2 (count xs))
+                            conj acc $ [] (get xs 1) (quote-replace (slice ~v ~idx))
+                          recur
+                            conj acc $ [] (first xs) (quote-replace (get ~v ~idx))
+                            rest xs
+                            inc idx
+              quote-replace
+                &let
+                  ~v ~data
+                  let
+                    ~ defs
+                    ~@ body
+
         |conj $ quote
           def conj append
 

--- a/tests/snapshots/test-list.cirru
+++ b/tests/snapshots/test-list.cirru
@@ -275,6 +275,23 @@
             assert= 10 (deref *counted)
             assert= 10 @*counted
 
+        |test-let[] $ quote
+          fn ()
+            log-title "|Testing let[]"
+            when
+              = :nim $ &get-calcit-backend
+              echo $ macroexpand $ quote
+                let[] (a b c & d) ([] 1 2 3 4 5)
+                  echo a
+                  echo b
+                  echo c
+                  echo d
+            let[] (a b c & d) ([] 1 2 3 4 5)
+              assert= 1 a
+              assert= 2 b
+              assert= 3 c
+              assert= ([] 4 5) d
+
         |main! $ quote
           defn main! ()
 
@@ -303,6 +320,7 @@
             test-sort
 
             test-doseq
+            test-let[]
 
             do true
 


### PR DESCRIPTION
Since `pr-str` and `read-string` of Clojure are not available for js in very simple code, functions `to-cirru-edn` and `extract-cirru-edn` are added which implemented Cirru EDN on top of JSON arrays. It can be used as a cheap way of stringify simple Calcit data.
