### PR TITLE
implement --emit-ir option for IR

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
 
     - name: "try js"
       run: >
-        nimble jsgen
+        nimble genjs
         && cd src/includes/ && npm install typescript
         && ./node_modules/.bin/tsc
         && cd ../../

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ cr compact.cirru --init-fn='app.main/main!' # specifying init-fn
 
 cr -e="range 100" # eval from CLI
 
+cr --emit-js # compile to js
+
+cr --emit-ir # compile to intermediate representation
+
 cr_once # bundled without wathcer and SDL2, for CI only
 ```
 
@@ -84,7 +88,10 @@ nimble once
 nimble e
 
 # for emitting js
-nimble jsgen
+nimble genjs
+
+# for emitting ir
+nimble genir
 ```
 
 ### Modules

--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -1,7 +1,7 @@
 
 # Package
 
-version       = "0.2.19"
+version       = "0.2.20"
 author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"

--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -40,8 +40,12 @@ task ct, "Runs calcit tests":
 task e, "eval some code":
   exec "nim compile --verbosity:0 --hints:off --threads:on -r src/cr -e='range 10'"
 
-task jsgen, "try generating js":
+task genjs, "try generating js":
   exec "nim compile --verbosity:0 --hints:off --threads:on -r src/cr_once --emit-js tests/snapshots/test.cirru --once"
+  # exec "nim compile --verbosity:0 --hints:off --threads:on -r src/cr --emit-js example/compact.cirru --once"
+
+task genir, "try generating ir":
+  exec "nim compile --verbosity:0 --hints:off --threads:on -r src/cr_once --emit-ir tests/snapshots/test.cirru --once"
   # exec "nim compile --verbosity:0 --hints:off --threads:on -r src/cr --emit-js example/compact.cirru --once"
 
 # task jsprocs, "generating js core lib core from Nim":

--- a/src/calcit_runner.nim
+++ b/src/calcit_runner.nim
@@ -90,9 +90,9 @@ proc emitCode(initFn, reloadFn: string): void =
   if reloadPair.len != 2:
     echo "Unknown reloadFn", reloadFn
     raise newException(ValueError, "Unknown reloadFn")
-  preprocessSymbolByPath(initPair[0], initPair[1])
-  preprocessSymbolByPath(reloadPair[0], reloadPair[1])
   try:
+    preprocessSymbolByPath(initPair[0], initPair[1])
+    preprocessSymbolByPath(reloadPair[0], reloadPair[1])
     if jsMode:
       emitJs(programData, initPair[0])
     elif irMode:

--- a/src/calcit_runner/emit_ir.nim
+++ b/src/calcit_runner/emit_ir.nim
@@ -100,7 +100,7 @@ proc emitIR*(programData: Table[string, ProgramFile], initFn, reloadFn: string):
         }
 
     let fileData = %* {
-      "ns": nsData, "defs": defsData
+      "import": nsData, "defs": defsData
     }
     files[ns] = fileData
 

--- a/src/calcit_runner/emit_ir.nim
+++ b/src/calcit_runner/emit_ir.nim
@@ -1,0 +1,121 @@
+
+import os
+import options
+import tables
+
+import cirru_edn
+import ternary_tree
+
+import ./types
+
+var irMode* = false
+var emitPath = "js-out"
+
+# mutual recursion
+proc dumpCode(xs: CirruData): CirruEdnValue
+
+proc dumpCode(xs: seq[CirruData]): CirruEdnValue =
+  var ys: seq[CirruEdnValue]
+  for item in xs:
+    ys.add dumpCode(item)
+
+  CirruEdnValue(kind: crEdnList, listVal: ys)
+
+proc dumpCode(xs: TernaryTreeList[CirruData]): CirruEdnValue =
+  var ys: seq[CirruEdnValue]
+  for item in xs:
+    ys.add dumpCode(item)
+
+  CirruEdnValue(kind: crEdnList, listVal: ys)
+
+proc kwd(x: string): CirruEdnValue =
+  genCrEdnKeyword(x)
+
+proc dumpCode(xs: CirruData): CirruEdnValue =
+  case xs.kind
+  of crDataNumber:
+    genCrEdn(xs.numberVal)
+  of crDataNil:
+    genCrEdn()
+  of crDataString:
+    genCrEdn(xs.stringVal)
+  of crDataBool:
+    genCrEdn(xs.boolVal)
+  of crDataKeyword:
+    kwd(xs.keywordVal)
+  of crDataProc:
+    genCrEdnMap(
+      kwd("kind"), kwd("proc"),
+    )
+  of crDataSymbol:
+    var resolvedData =
+      if xs.resolved.isSome():
+        let resolved = xs.resolved.get()
+        genCrEdnMap(
+          kwd("ns"), genCrEdn(resolved.ns),
+          kwd("def"), genCrEdn(resolved.def),
+          kwd("ns-in-str?"), genCrEdn(resolved.nsInStr),
+        )
+      else:
+        genCrEdn()
+    genCrEdnMap(
+      kwd("kind"), kwd("symbol"),
+      kwd("val"), genCrEdn(xs.symbolVal),
+      kwd("ns"), genCrEdn(xs.ns),
+      kwd("dynamic?"), genCrEdn(xs.dynamic),
+      kwd("resolved"), resolvedData,
+    )
+  of crDataFn:
+    genCrEdnMap(
+      kwd("kind"), kwd("fn"),
+      kwd("ns"), genCrEdn(xs.fnNs),
+      kwd("name"), genCrEdn(xs.fnName),
+      kwd("args"), dumpCode(xs.fnArgs),
+      kwd("code"), dumpCode(xs.fnCode)
+    )
+  of crDataThunk:
+    dumpCode(xs.thunkCode[])
+  of crDataList:
+    dumpCode(xs.listVal)
+  else:
+    genCrEdn("...TODO")
+
+proc emitIR*(programData: Table[string, ProgramFile], initFn, reloadFn: string): void =
+  var files = CirruEdnValue(kind: crEdnMap, mapVal: initTable[CirruEdnValue, CirruEdnValue]())
+  let configs = genCrEdnMap(
+    genCrEdn("init-fn"), genCrEdn(initFn),
+    genCrEdn("reload-fn"), genCrEdn(reloadFn),
+  )
+
+  for ns, file in programData:
+
+    var defsData = CirruEdnValue(kind: crEdnMap, mapVal: initTable[CirruEdnValue, CirruEdnValue]())
+    for def, defCode in file.defs:
+      defsData.mapVal[genCrEdn(def)] = dumpCode(defCode)
+
+    var nsData = CirruEdnValue(kind: crEdnMap, mapVal: initTable[CirruEdnValue, CirruEdnValue]())
+    if file.ns.isSome():
+      for target, importRule in file.ns.get():
+        nsData.mapVal[genCrEdn(target)] = genCrEdnMap(
+          genCrEdn("ns"), genCrEdn(importRule.ns),
+          genCrEdn("ns-in-str?"), genCrEdn(importRule.nsInStr),
+          genCrEdn("def"), genCrEdn(),
+        )
+
+    let fileData = genCrEdnMap(
+      genCrEdn("ns"), nsData,
+      genCrEdn("defs"), defsData,
+    )
+    files.mapVal[genCrEdn(ns)] = fileData
+
+  let data = genCrEdnMap(
+    genCrEdn("configs"), configs,
+    genCrEdn("files"), files,
+  )
+
+  let content = data.formatToCirru(true)
+  if dirExists(emitPath).not:
+    createDir(emitPath)
+
+  writeFile (emitPath & "/program-ir.cirru"), content
+  echo "emitted to ", (emitPath & "/program-ir.cirru")

--- a/src/calcit_runner/emit_js.nim
+++ b/src/calcit_runner/emit_js.nim
@@ -473,7 +473,7 @@ proc emitJs*(programData: Table[string, ProgramFile], entryNs: string): void =
 
     if implicitImports.len > 0 and file.ns.isSome():
       let importsInfo = file.ns.get()
-      echo "imports: ", implicitImports
+      # echo "imports: ", implicitImports
       for def, defNs in implicitImports:
         # if not importsInfo.contains(def):
         # echo "implicit import ", defNs, "/", def, " in ", ns

--- a/src/calcit_runner/emit_js.nim
+++ b/src/calcit_runner/emit_js.nim
@@ -393,7 +393,7 @@ proc writeFileIfChanged(filename: string, content: string): bool =
   writeFile filename, content
   return true
 
-proc emitJs*(programData: Table[string, ProgramFile], entryNs, entryDef: string): void =
+proc emitJs*(programData: Table[string, ProgramFile], entryNs: string): void =
   if dirExists(jsEmitPath).not:
     createDir(jsEmitPath)
 

--- a/src/calcit_runner/evaluate.nim
+++ b/src/calcit_runner/evaluate.nim
@@ -75,8 +75,8 @@ proc interpretSymbol(sym: CirruData, scope: CirruDataScope, ns: string): CirruDa
   let coreDefs = programData[coreNs].defs
   if coreDefs.contains(sym.symbolVal):
     return coreDefs[sym.symbolVal]
-  let loadedSym = preprocess(sym, toHashset[string](@[]), ns)
 
+  let loadedSym = preprocess(sym, toHashset[string](@[]), ns)
   echo "[Warn] load unprocessed variable: ", sym
   if loadedSym.resolved.isSome:
     let path = loadedSym.resolved.get

--- a/src/calcit_runner/version.nim
+++ b/src/calcit_runner/version.nim
@@ -1,2 +1,2 @@
 
-let commandLineVersion* = "0.2.19"
+let commandLineVersion* = "0.2.20"

--- a/src/cr.nim
+++ b/src/cr.nim
@@ -14,6 +14,7 @@ import ./calcit_runner/watcher
 import ./calcit_runner/version
 import ./calcit_runner/event_loop
 import ./calcit_runner/emit_js
+import ./calcit_runner/emit_ir
 import ./calcit_runner/color_echo
 
 var runOnce = false
@@ -86,10 +87,12 @@ while true:
       if cliArgs.val == "" or cliArgs.val == "true":
         runOnce = true
         dimEcho "Runner: watching mode disabled."
-    if cliArgs.key == "init-fn" and cliArgs.val != "":
+    elif cliArgs.key == "init-fn" and cliArgs.val != "":
       initFn = some(cliArgs.val)
-    if cliArgs.key == "emit-js":
+    elif cliArgs.key == "emit-js":
       jsMode = true
+    elif cliArgs.key == "emit-ir":
+      irMode = true
   of cmdArgument:
     snapshotFile = cliArgs.key
     incrementFile = cliArgs.key.replace("compact", ".compact-inc")

--- a/src/cr_once.nim
+++ b/src/cr_once.nim
@@ -5,6 +5,7 @@ import options
 
 import ./calcit_runner
 import ./calcit_runner/emit_js
+import ./calcit_runner/emit_ir
 import ./calcit_runner/version
 import ./calcit_runner/color_echo
 
@@ -30,8 +31,10 @@ while true:
   of cmdLongOption:
     if cliArgs.key == "init-fn" and cliArgs.val != "":
       initFn = some(cliArgs.val)
-    if cliArgs.key == "emit-js":
+    elif cliArgs.key == "emit-js":
       jsMode = true
+    elif cliArgs.key == "emit-ir":
+      irMode = true
   of cmdArgument:
     snapshotFile = cliArgs.key
     dimEcho "Runner: specifying files", snapshotFile

--- a/tests/snapshots/test.cirru
+++ b/tests/snapshots/test.cirru
@@ -107,6 +107,9 @@
             log-title "|Testing display stack"
             display-stack "|show stack here"
 
+        |reload! $ quote
+          defn reload! () nil
+
         |main! $ quote
           defn main! ()
             log-title "|Testing keyword function"


### PR DESCRIPTION
New feature `cr --emit-ir` can be use to dump program information into a JSON file. The same information can be used to generate JavaScript code, which was done in `--emit-js`. The information has not been verified but mostly dumped from `programData` to JSON, almost directly. That should be sufficient for code generation.

A simple demo can be found at https://gist.github.com/jiyinyiyong/b15ab9fa4467b8f8e09b5a291c84f655 .
