### PR TITLE
calcit-js: refine codegen for &let

### DIFF
--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -1,7 +1,7 @@
 
 # Package
 
-version       = "0.2.40"
+version       = "0.2.41"
 author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^14.14.21",

--- a/src/calcit_runner.nim
+++ b/src/calcit_runner.nim
@@ -134,6 +134,8 @@ proc loadModules(modulePath: string, baseDir: string) =
     fullpath = modulePath
   else:
     fullpath = getEnv("HOME").joinPath(".config/calcit/modules/", modulePath)
+  if fullpath.endsWith("/"):
+    fullpath = fullpath & "compact.cirru"
   echo "Loading module: ", fullpath
   let snapshotInfo = loadSnapshot(fullpath)
 

--- a/src/calcit_runner/version.nim
+++ b/src/calcit_runner/version.nim
@@ -1,2 +1,2 @@
 
-let commandLineVersion* = "0.2.40"
+let commandLineVersion* = "0.2.41"

--- a/tests/snapshots/fibo.cirru
+++ b/tests/snapshots/fibo.cirru
@@ -12,6 +12,9 @@
             ; try-fibo
             echo $ sieve-primes ([] 2 3 5 7 11 13) 17 400
 
+        |reload! $ quote
+          defn reload! () nil
+
         |try-fibo $ quote
           defn try-fibo ()
             let


### PR DESCRIPTION
for expression:

```cirru
&let (a b)
 c
```

Now generates:

```js
((a)=>{
  return c
})(b)
```

Previsouly:

```js
(()=> {
  let a = b;
  return c
})()
```

Use `let a = b`, may encounter `let a = a` which is a syntax error.
