### PR TITLE
experimental support of lambda alias syntax

### DIFF
--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -1,7 +1,7 @@
 
 # Package
 
-version       = "0.2.76"
+version       = "0.2.77"
 author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -220,7 +220,7 @@ export let _AND__EQ_ = (x: CrDataValue, y: CrDataValue): boolean => {
         if (!y.contains(k)) {
           return false;
         }
-        if (!_AND__EQ_(v, get(y, k))) {
+        if (!_AND__EQ_(v, _AND_get(y, k))) {
           return false;
         }
       }
@@ -343,24 +343,32 @@ export let includes_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
   throw new Error("includes? expected a structure");
 };
 
-export let get = function (xs: CrDataValue, k: CrDataValue) {
+export let nth = function (xs: CrDataValue, k: CrDataValue) {
   if (arguments.length !== 2) {
-    throw new Error("get takes 2 arguments");
+    throw new Error("nth takes 2 arguments");
+  }
+  if (typeof k !== "number") {
+    throw new Error("Expected number index for a list");
   }
 
   if (typeof xs === "string") {
-    if (typeof k === "number") {
-      return xs[k];
-    } else {
-      throw new Error("Expected number index for a string");
-    }
+    return xs[k];
   }
   if (xs instanceof CrDataList) {
-    if (typeof k !== "number") {
-      throw new Error("Expected number index for a list");
-    }
     return xs.get(k);
   }
+  if (Array.isArray(xs)) {
+    return xs[k];
+  }
+
+  throw new Error("Does not support `nth` on this type");
+};
+
+export let _AND_get = function (xs: CrDataValue, k: CrDataValue) {
+  if (arguments.length !== 2) {
+    throw new Error("&get takes 2 arguments");
+  }
+
   if (xs instanceof CrDataMap) {
     if (xs.contains(k)) {
       return xs.get(k);
@@ -368,15 +376,17 @@ export let get = function (xs: CrDataValue, k: CrDataValue) {
       return null;
     }
   }
-  if (Array.isArray(xs)) {
-    if (typeof k === "number") {
-      return xs[k];
-    } else {
-      throw new Error("Expected number index for an array");
-    }
+  if (xs == null) {
+    throw new Error("`&get` does not work on `nil`, need to use `get`");
+  }
+  if (typeof xs === "string") {
+    return nth(xs, k);
+  }
+  if (xs instanceof CrDataList) {
+    return nth(xs, k);
   }
 
-  throw new Error("Does not support `get` on this type");
+  throw new Error("Does not support `&get` on this type");
 };
 
 export let assoc = function (xs: CrDataValue, k: CrDataValue, v: CrDataValue) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.2.76",
+  "version": "0.2.77",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^14.14.21",

--- a/src/calcit_runner/compiler_configs.nim
+++ b/src/calcit_runner/compiler_configs.nim
@@ -7,7 +7,7 @@ import strutils
 # calcit-runner is used for both evaling and compiling to js
 # configs collected in order to expose to whole program
 
-let commandLineVersion* = "0.2.76"
+let commandLineVersion* = "0.2.77"
 
 # dirty states controlling js backend
 var jsMode* = false

--- a/src/calcit_runner/data.nim
+++ b/src/calcit_runner/data.nim
@@ -188,3 +188,12 @@ proc parseLiteral*(token: string, ns: string): CirruData =
     ]))
   else:
     return CirruData(kind: crDataSymbol, symbolVal: token, ns: ns)
+
+# for detecting lambda alias syntax `\x x`.
+# Notice: this is not in code reader, but in preprocessor. so macros won't handle this
+proc isLambdaAlias*(x: CirruData): bool =
+  if x.kind == crDataSymbol:
+    let token = x.symbolVal
+    token.len >= 2 and token[0] == '\\' and token[1..^1].matchesSimpleVar()
+  else:
+    false

--- a/src/calcit_runner/evaluate.nim
+++ b/src/calcit_runner/evaluate.nim
@@ -303,6 +303,18 @@ proc preprocess*(code: CirruData, localDefs: Hashset[string], ns: string): Cirru
   of crDataList:
     if code.listVal.len == 0:
       return code
+    elif code.listVal.len >= 2 and isLambdaAlias(code.listVal[0]):
+      # for detecting lambda alias syntax `\x x`
+      let token = code.listVal[0].symbolVal
+      let expandedCode = CirruData(kind: crDataList, listVal: initCrVirtualList(@[
+        CirruData(kind: crDataSymbol, symbolVal: "defn", ns: ns),
+        CirruData(kind: crDataSymbol, symbolVal: "fn_" & token[1..^1], ns: ns),
+        CirruData(kind: crDataList, listVal: initCrVirtualList(@[
+          CirruData(kind: crDataSymbol, symbolVal: token[1..^1], ns: ns),
+        ])),
+        CirruData(kind: crDataList, listVal: code.listVal.rest()),
+      ]))
+      return preprocess(expandedCode, localDefs, ns)
     else:
       let head = code.listVal[0]
       let originalValue = preprocess(head, localDefs, ns)

--- a/src/includes/calcit-core.cirru
+++ b/src/includes/calcit-core.cirru
@@ -315,6 +315,15 @@
                 &let (~v ~item)
                   &case ~v ~default ~@patterns
 
+        |get $ quote
+          defn get (base k)
+            cond
+              (nil? base) nil
+              (string? base) (nth base k)
+              (map? base) (&get base k)
+              (list? base) (nth base k)
+              true $ raise "|Expected map or list for get"
+
         |get-in $ quote
           defn get-in (base path)
             assert "|expects path in a list" (list? path)

--- a/src/includes/calcit-core.cirru
+++ b/src/includes/calcit-core.cirru
@@ -480,7 +480,9 @@
           defmacro \ (& xs)
             if (contains-symbol? xs '%2)
               quote-replace $ fn (% %2) ~xs
-              quote-replace $ fn (%) ~xs
+              if (contains-symbol? xs '%)
+                quote-replace $ fn (%) ~xs
+                quote-replace $ fn () ~xs
 
         |has-index? $ quote
           defn has-index? (xs idx)

--- a/tests/snapshots/test-js.cirru
+++ b/tests/snapshots/test-js.cirru
@@ -41,7 +41,7 @@
               set! (.-a a) 2
               assert= (.-a a) 2
 
-            assert= 2 $ get (to-js-data $ [] 1 2 3) 1
+            assert= 2 $ nth (to-js-data $ [] 1 2 3) 1
 
             assert-detect identity $ instance? js/Number (new js/Number 1)
             assert-detect not $ instance? js/String (new js/Number 1)
@@ -55,7 +55,7 @@
                 c $ + a b
                 b 4
                 d 5
-              echo $ + a b c d
+              assert= 13 $ + a b c d
 
         |main! $ quote
           defn main! ()

--- a/tests/snapshots/test-macro.cirru
+++ b/tests/snapshots/test-macro.cirru
@@ -140,7 +140,7 @@
             assert= 36
               ->% 3 (+ % %) (* % %)
 
-        |test-labmda $ quote
+        |test-lambda $ quote
           fn ()
             log-title "|Testing lambda macro"
 
@@ -171,7 +171,7 @@
 
               assert=
                 macroexpand-all $ quote $ \ x
-                quote $ defn f% (%) (x)
+                quote $ defn f% () (x)
 
               assert=
                 macroexpand-all $ quote $ \ + x %
@@ -180,6 +180,10 @@
               assert=
                 macroexpand-all $ quote $ \ + x % %2
                 quote $ defn f% (% %2) (+ x % %2)
+
+            ; "special syntax inside preprocess"
+            assert= 3
+              (\x + x 1) 2
 
         |test-gensym $ quote
           fn ()
@@ -343,7 +347,7 @@
 
             test-thread-macros
 
-            test-labmda
+            test-lambda
 
             log-title "|Testing gensym"
             test-gensym

--- a/tests/snapshots/test-map.cirru
+++ b/tests/snapshots/test-map.cirru
@@ -138,6 +138,8 @@
             assert= nil $ get (&{}) :a
             assert= nil $ get-in (&{}) $ [] :a :b
 
+            assert= nil $ get nil :a
+
         |main! $ quote
           defn main! ()
 

--- a/tests/snapshots/test-string.cirru
+++ b/tests/snapshots/test-string.cirru
@@ -104,6 +104,8 @@
             assert= 97 $ get-char-code |a
             assert= 27721 $ get-char-code |汉
 
+            assert= |a $ nth |abc 0
+            assert= |b $ nth |abc 1
             assert= |a $ first |abc
             assert= |c $ last |abc
             assert= nil $ first |


### PR DESCRIPTION
this change makes it possible to write `fn (x) y` in a shorter form of `\x y`. While it's really short, it also brings inconsistency in macro since this won't work in `macroexpand`. The expansion happens inside `preprocess` function, so it's quite tricky being a special syntax. Luckily this won't create problem in calcit-js.
