### PR TITLE
calcit-js: refine namespace codegen to fix confliction

### DIFF
--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -1,7 +1,7 @@
 
 # Package
 
-version       = "0.2.99"
+version       = "0.2.100"
 author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"

--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -1,7 +1,7 @@
 
 # Package
 
-version       = "0.2.98"
+version       = "0.2.99"
 author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"

--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -1,7 +1,7 @@
 
 # Package
 
-version       = "0.2.97"
+version       = "0.2.98"
 author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"

--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -1,7 +1,7 @@
 
 # Package
 
-version       = "0.2.96"
+version       = "0.2.97"
 author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -1045,6 +1045,12 @@ export let to_js_data = (x: CrDataValue, addColon: boolean = false): any => {
     }
     return x.value;
   }
+  if (x instanceof CrDataSymbol) {
+    if (addColon) {
+      return `:${x.value}`;
+    }
+    return Symbol(x.value);
+  }
   if (x instanceof CrDataList) {
     var result: any[] = [];
     for (let item of x.items()) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.97",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
-    "@types/node": "^14.14.33",
+    "@types/node": "^14.14.34",
     "typescript": "^4.2.3",
     "vite": "^2.0.5",
     "webpack": "^5.25.0",
@@ -16,6 +16,6 @@
   "dependencies": {
     "@calcit/ternary-tree": "0.0.12",
     "@cirru/parser.ts": "^0.0.1",
-    "@cirru/writer.ts": "^0.1.2"
+    "@cirru/writer.ts": "^0.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.2.99",
+  "version": "0.2.100",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^14.14.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.2.97",
+  "version": "0.2.98",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^14.14.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.2.98",
+  "version": "0.2.99",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^14.14.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.2.96",
+  "version": "0.2.97",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^14.14.33",

--- a/src/calcit_runner.nim
+++ b/src/calcit_runner.nim
@@ -109,10 +109,12 @@ proc emitCode(initFn, reloadFn: string): void =
   try:
     preprocessSymbolByPath(initPair[0], initPair[1])
     preprocessSymbolByPath(reloadPair[0], reloadPair[1])
+
+    if irMode:
+      emitIR(programData, initFn, reloadFn)
+
     if jsMode:
       emitJs(programData, initPair[0])
-    elif irMode:
-      emitIR(programData, initFn, reloadFn)
     else:
       raise newException(ValueError, "Unknown mode")
   except CirruEvalError as e:
@@ -207,7 +209,7 @@ proc reloadProgram(snapshotFile: string): void =
     programCode[fileNs] = file
   echo "clearing data under package: ", codeConfigs.pkg
   clearProgramDefs(programData, codeConfigs.pkg)
-  genSymIndex = 0 # make it a litter stabler
+  genSymIndex = 0 # make it a litter more stable
   programCode[coreNs] = previousCoreSource
   var pieces = codeConfigs.reloadFn.split('/')
 

--- a/src/calcit_runner.nim
+++ b/src/calcit_runner.nim
@@ -213,6 +213,9 @@ proc reloadProgram(snapshotFile: string): void =
   programCode[coreNs] = previousCoreSource
   var pieces = codeConfigs.reloadFn.split('/')
 
+  # also notice that programData is not being cleared during reload
+  # which leads to dirty caches inside progam. might cause future bugs
+
   if jsMode or irMode:
     emitCode(codeConfigs.initFn, codeConfigs.reloadFn)
   else:

--- a/src/calcit_runner/codegen/emit_js.nim
+++ b/src/calcit_runner/codegen/emit_js.nim
@@ -169,8 +169,11 @@ proc toJsCode(xs: CirruData, ns: string, localDefs: HashSet[string]): string =
     elif xs.resolved.kind == resolvedLocal or localDefs.contains(xs.symbolVal):
       return xs.symbolVal.escapeVar()
     elif xs.resolved.kind == resolvedDef:
-      # TODO ditry code
+      if xs.resolved.ns == coreNs:
+        # functions under core uses built $calcit module entry
+        return varPrefix & xs.symbolVal.escapeVar()
       let resolved = xs.resolved
+      # TODO ditry code
       if collectedImports.contains(xs.symbolVal):
         let prev = collectedImports[xs.symbolVal]
         if prev.ns != resolved.ns:
@@ -178,10 +181,7 @@ proc toJsCode(xs: CirruData, ns: string, localDefs: HashSet[string]): string =
           raiseEvalError("Conflicted implicit imports", xs)
       else:
         collectedImports[xs.symbolVal] = (ns: resolved.ns, justNs: false, nsInStr: resolved.nsInStr)
-      if xs.resolved.ns == coreNs:
-        return varPrefix & xs.symbolVal.escapeVar()
-      else:
-        return xs.symbolVal.escapeVar()
+      return xs.symbolVal.escapeVar()
     elif xs.ns == coreNs:
       # local variales inside calcit.core also uses this ns
       echo "[Warn] detected variable inside core not resolved"

--- a/src/calcit_runner/codegen/emit_js.nim
+++ b/src/calcit_runner/codegen/emit_js.nim
@@ -42,10 +42,6 @@ proc toJsFileName(ns: string): string =
   else:
     ns & ".js"
 
-proc hasNsPart(x: string): bool =
-  let trySlashPos = x.find('/')
-  return trySlashPos >= 1 and trySlashPos < x.len - 1
-
 proc escapeVar(name: string): string =
   if name.hasNsPart():
     raise newException(ValueError, "Invalid variable name `" & name & "`, use `escapeNsVar` instead")

--- a/src/calcit_runner/codegen/emit_js.nim
+++ b/src/calcit_runner/codegen/emit_js.nim
@@ -357,7 +357,7 @@ proc toJsCode(xs: CirruData, ns: string, localDefs: HashSet[string]): string =
         let item = body[0]
         if item.kind != crDataSymbol: raiseEvalError("expected a symbol", xs)
         let target = item.toJsCode(ns, localDefs)
-        return "(typeof {" & target & "} !== 'undefined')"
+        return "(typeof " & target & " !== 'undefined')"
       of "new":
         if xs.listVal.len < 2:
           raiseEvalError("`new` takes at least an object constructor", xs)

--- a/src/calcit_runner/compiler_configs.nim
+++ b/src/calcit_runner/compiler_configs.nim
@@ -7,7 +7,7 @@ import strutils
 # calcit-runner is used for both evaling and compiling to js
 # configs collected in order to expose to whole program
 
-let commandLineVersion* = "0.2.98"
+let commandLineVersion* = "0.2.99"
 
 # dirty states controlling js backend
 var jsMode* = false

--- a/src/calcit_runner/compiler_configs.nim
+++ b/src/calcit_runner/compiler_configs.nim
@@ -7,7 +7,7 @@ import strutils
 # calcit-runner is used for both evaling and compiling to js
 # configs collected in order to expose to whole program
 
-let commandLineVersion* = "0.2.96"
+let commandLineVersion* = "0.2.97"
 
 # dirty states controlling js backend
 var jsMode* = false

--- a/src/calcit_runner/compiler_configs.nim
+++ b/src/calcit_runner/compiler_configs.nim
@@ -7,7 +7,7 @@ import strutils
 # calcit-runner is used for both evaling and compiling to js
 # configs collected in order to expose to whole program
 
-let commandLineVersion* = "0.2.97"
+let commandLineVersion* = "0.2.98"
 
 # dirty states controlling js backend
 var jsMode* = false

--- a/src/calcit_runner/compiler_configs.nim
+++ b/src/calcit_runner/compiler_configs.nim
@@ -7,7 +7,7 @@ import strutils
 # calcit-runner is used for both evaling and compiling to js
 # configs collected in order to expose to whole program
 
-let commandLineVersion* = "0.2.99"
+let commandLineVersion* = "0.2.100"
 
 # dirty states controlling js backend
 var jsMode* = false

--- a/src/calcit_runner/evaluate.nim
+++ b/src/calcit_runner/evaluate.nim
@@ -18,6 +18,7 @@ import ./compiler_configs
 
 import ./util/errors
 import ./util/stack
+import ./util/str_util
 import ./eval/arguments
 import ./eval/expression
 import ./codegen/special_calls
@@ -217,7 +218,7 @@ proc preprocess*(code: CirruData, localDefs: Hashset[string], ns: string): Cirru
   # echo "\nPreprocess: ", code
   case code.kind
   of crDataSymbol:
-    if code.symbolVal.contains("/") and code.symbolVal[0] != '/' and code.symbolVal[^1] != '/':
+    if code.symbolVal.hasNsPart():
       var sym = code
       let pieces = sym.symbolVal.split('/')
       if pieces.len != 2:

--- a/src/calcit_runner/util/set_util.nim
+++ b/src/calcit_runner/util/set_util.nim
@@ -1,0 +1,7 @@
+
+import tables
+import sets
+
+proc getTableKeys*[T](x: Table[string, T]): HashSet[string] =
+  for k in x.keys:
+    result.incl(k)

--- a/src/calcit_runner/util/str_util.nim
+++ b/src/calcit_runner/util/str_util.nim
@@ -106,3 +106,7 @@ proc matchesJsVar*(xs: string): bool =
         continue
     return false
   return true
+
+proc hasNsPart*(x: string): bool =
+  let trySlashPos = x.find('/')
+  return trySlashPos >= 1 and trySlashPos < x.len - 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@cirru/parser.ts/-/parser.ts-0.0.1.tgz#0870b051bd9f56626759ec22d7a0d5c51b19fe9c"
   integrity sha512-FlUWZ2VqIUK/5cG926CVw9fQ7IGQzRDz8NL2Zc1lK2NyvOltAyZEDxxj/ztWjGOOnetVtM5mDx8rsbsr/SLYhg==
 
-"@cirru/writer.ts@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@cirru/writer.ts/-/writer.ts-0.1.2.tgz#1fa667c2fbdcf083901654b771ed40879d2998e1"
-  integrity sha512-TU1uNk6ei+qsaEY7w9kHyGrAoAYkfDjZu5XyHUjb4i4UvAC+c5EHeA6rVPQL7IhIeFJeFgrnBNb7LizduzWpgA==
+"@cirru/writer.ts@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@cirru/writer.ts/-/writer.ts-0.1.3.tgz#5f54bdecaa20ba3dab16cbe6da711854138a9c0a"
+  integrity sha512-vJnhmhm7we5UfQIwmZfQpF3bAFbVybzT6LbmkbQHxgijaQg3gPfNVsnSIa3g3KpmWVtvkzEx+nUy5aMwsJiV1A==
 
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.2"
@@ -48,10 +48,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
-"@types/node@*", "@types/node@^14.14.33":
-  version "14.14.33"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.33.tgz#9e4f8c64345522e4e8ce77b334a8aaa64e2b6c78"
-  integrity sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==
+"@types/node@*", "@types/node@^14.14.34":
+  version "14.14.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.34.tgz#07935194fc049069a1c56c0c274265abeddf88da"
+  integrity sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==
 
 "@webassemblyjs/ast@1.11.0":
   version "1.11.0"
@@ -663,9 +663,9 @@ resolve@^1.19.0, resolve@^1.9.0:
     path-parse "^1.0.6"
 
 rollup@^2.38.5:
-  version "2.41.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.41.1.tgz#c7c7ada42b13be505facd516f13fb697c24c1116"
-  integrity sha512-nepLFAW5W71/MWpS2Yr7r31eS7HRfYg2RXnxb6ehqN9zY42yACxKtEfb4xq8SmNfUohAzGMcyl6jkwdLOAiUbg==
+  version "2.41.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.41.2.tgz#b7db5cb7c21c2d524e8b26ef39c7e9808a290c7e"
+  integrity sha512-6u8fJJXJx6fmvKrAC9DHYZgONvSkz8S9b/VFBjoQ6dkKdHyPpPbpqiNl2Bao9XBzDHpq672X6sGZ9G1ZBqAHMg==
   optionalDependencies:
     fsevents "~2.3.1"
 


### PR DESCRIPTION
In my previous code, `respo.schema :as schema` is imported. Then in another file `alerts.schema :as schema` is imported. When they are in different files, it's totally okay to be both called `schema`. However, with macros, these two symbols will be inside one file.

Now the namespaces are generating `$respo_DOT_schema` and `$alerts_DOT_schema` so they can coexist inside one file.
