### PR TITLE
Change string format; turn caught error into a record or an object

### DIFF
--- a/calcit_runner.nimble
+++ b/calcit_runner.nimble
@@ -1,7 +1,7 @@
 
 # Package
 
-version       = "0.2.103"
+version       = "0.2.104"
 author        = "jiyinyiyong"
 description   = "Script runner for Cirru"
 license       = "MIT"

--- a/lib/calcit-data.ts
+++ b/lib/calcit-data.ts
@@ -191,16 +191,13 @@ export class CrDataList {
   toString(shorter = false): string {
     let result = "";
     for (let item of this.items()) {
-      if (result !== "") {
-        result = `${result}, `;
-      }
       if (shorter && isNestedCrData(item)) {
-        result = `${result}${tipNestedCrData(item)}`;
+        result = ` ${result}${tipNestedCrData(item)}`;
       } else {
-        result = `${result}${toString(item, true)}`;
+        result = ` ${result}${toString(item, true)}`;
       }
     }
-    return `(${result})`;
+    return `([]${result}`;
   }
   isEmpty() {
     return this.len() === 0;
@@ -350,19 +347,15 @@ export class CrDataMap {
   toString(shorter = false) {
     let itemsCode = "";
     for (let [k, v] of this.pairs()) {
-      if (itemsCode !== "") {
-        itemsCode = `${itemsCode}, `;
-      }
-
       if (shorter) {
         let keyPart = isNestedCrData(k) ? tipNestedCrData(k) : toString(k, true);
         let valuePart = isNestedCrData(v) ? tipNestedCrData(v) : toString(k, true);
-        itemsCode = `${itemsCode}${keyPart} ${valuePart}`;
+        itemsCode = ` (${itemsCode}${keyPart} ${valuePart})`;
       } else {
-        itemsCode = `${itemsCode}${toString(k, true)} ${toString(v, true)}`;
+        itemsCode = ` (${itemsCode}${toString(k, true)} ${toString(v, true)})`;
       }
     }
-    return `{${itemsCode}}`;
+    return `({}${itemsCode})`;
   }
   isEmpty() {
     let cursor = this.chain;
@@ -488,16 +481,11 @@ export class CrDataRecord {
     // TODO
   }
   toString(): string {
-    let ret = "%{" + this.name;
+    let ret = "(%{} " + this.name;
     for (let idx in this.fields) {
-      if (idx === "0") {
-        ret += " ";
-      } else {
-        ret += ", ";
-      }
-      ret += this.fields[idx] + " " + toString(this.values[idx], true);
+      ret += " (" + this.fields[idx] + " " + toString(this.values[idx], true) + ")";
     }
-    return ret + " }";
+    return ret + ")";
   }
 }
 
@@ -759,11 +747,8 @@ export class CrDataSet {
   toString() {
     let itemsCode = "";
     this.value.forEach((child, idx) => {
-      if (itemsCode !== "") {
-        itemsCode = `${itemsCode} `;
-      }
-      itemsCode = `${itemsCode}${toString(child, true)}`;
+      itemsCode = ` ${itemsCode}${toString(child, true)}`;
     });
-    return `#{${itemsCode}}`;
+    return `(#{}${itemsCode})`;
   }
 }

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -316,10 +316,6 @@ export let _AND_str = (x: CrDataValue): string => {
   return `${x}`;
 };
 
-export let raise = (x: string): void => {
-  throw new Error(x);
-};
-
 export let contains_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
   if (typeof xs === "string") {
     if (typeof x != "number") {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.2.103",
+  "version": "0.2.104",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^14.14.34",

--- a/src/calcit_runner/compiler_configs.nim
+++ b/src/calcit_runner/compiler_configs.nim
@@ -7,7 +7,7 @@ import strutils
 # calcit-runner is used for both evaling and compiling to js
 # configs collected in order to expose to whole program
 
-let commandLineVersion* = "0.2.103"
+let commandLineVersion* = "0.2.104"
 
 # dirty states controlling js backend
 var jsMode* = false

--- a/src/calcit_runner/core_func.nim
+++ b/src/calcit_runner/core_func.nim
@@ -234,11 +234,14 @@ proc nativeRest(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataSc
     raiseEvalError(fmt"Cannot rest from data of this type: {a.kind}", a)
 
 proc nativeRaise(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
-  if args.len != 1: raiseEvalError("Expected 1 argument1 in native raise", args)
+  if args.len <= 1 or args.len > 2: raiseEvalError("Expected 1~2 arguments in native raise", args)
   let a = args[0]
   if a.kind != crDataString:
     raiseEvalError("Expect message in string", a)
-  raiseEvalError(a.stringVal, args)
+  var data = CirruData(kind: crDataNil)
+  if args.len >= 2:
+    data = args[1]
+  raiseEvalErrorData(a.stringVal, args, data)
 
 proc nativeTypeOf(args: seq[CirruData], interpret: FnInterpret, scope: CirruDataScope, ns: string): CirruData =
   if args.len != 1: raiseEvalError("type gets 1 argument", args)

--- a/src/calcit_runner/types.nim
+++ b/src/calcit_runner/types.nim
@@ -151,34 +151,27 @@ proc `$`*(xs: seq[CirruData]): string
 proc toString*(val: CirruData, stringDetail: bool, symbolDetail: bool): string
 
 proc fromListToString(children: seq[CirruData], symbolDetail: bool): string =
-  return "(" & children.mapIt(toString(it, true, symbolDetail)).join(" ") & ")"
+  return "([] " & children.mapIt(toString(it, true, symbolDetail)).join(" ") & ")"
 
 proc fromSetToString(children: HashSet[CirruData], symbolDetail: bool): string =
-  return "#{" & children.mapIt(toString(it, true, symbolDetail)).join(" ") & "}"
+  return "(#{} " & children.mapIt(toString(it, true, symbolDetail)).join(" ") & ")"
 
 proc fromMapToString(children: TernaryTreeMap[CirruData, CirruData], symbolDetail: bool): string =
   let size = children.len()
   if size > 100:
-    return "{...(100)...}"
-  var tableStr = "{"
-  var counted = 0
+    return "({} 100+...)"
+  var tableStr = "({}"
   for k, child in pairs(children):
-    tableStr = tableStr & toString(k, true, symbolDetail) & " " & toString(child, true, symbolDetail)
-    counted = counted + 1
-    if counted < children.len:
-      tableStr = tableStr & ", "
-  tableStr = tableStr & "}"
-  return tableStr
+    tableStr = tableStr & " (" &
+               toString(k, true, symbolDetail) & " " &
+               toString(child, true, symbolDetail) & ")"
+  return tableStr & ")"
 
 proc fromRecordToString(name: string, fields: seq[string], values: seq[CirruData], symbolDetail: bool): string =
-  result = "%{" & name
+  result = "(%{} " & name
   for idx, fieldName in fields:
-    if idx == 0:
-      result &= " "
-    else:
-      result &= ", "
-    result &= fieldName & " " & toString(values[idx], true, symbolDetail)
-  result &= " }"
+    result &= " (" & fieldName & " " & toString(values[idx], true, symbolDetail) & ")"
+  result &= ")"
 
 # based on https://github.com/nim-lang/Nim/blob/version-1-4/lib/pure/strutils.nim#L2322
 # strutils.escape turns Chinese into longer something "\xE6\xB1\x89",

--- a/src/calcit_runner/util/errors.nim
+++ b/src/calcit_runner/util/errors.nim
@@ -7,6 +7,7 @@ import ../data/virtual_list
 
 type CirruEvalError* = ref object of ValueError
   code*: CirruData
+  data*: CirruData
 
 proc raiseEvalError*(msg: string, code: CirruData): void =
   var e: CirruEvalError
@@ -23,3 +24,11 @@ proc raiseEvalError*(msg: string, xs: CrVirtualList[CirruData]): void =
 proc raiseEvalError*(msg: string, xs: seq[CirruData]): void =
   let code = CirruData(kind: crDataList, listVal: initCrVirtualList(xs))
   raiseEvalError(msg, code)
+
+proc raiseEvalErrorData*(msg: string, code: seq[CirruData], data: CirruData): void =
+  var e: CirruEvalError
+  new e
+  e.msg = msg
+  e.code = CirruData(kind: crDataList, listVal: initCrVirtualList(code))
+  e.data = data
+  raise e

--- a/tests/snapshots/test-string.cirru
+++ b/tests/snapshots/test-string.cirru
@@ -92,7 +92,7 @@
 
             inside-nim:
 
-              assert= "|{:c (3), :a 1, :b |2, :d {(1 2) 3}}"
+              assert= "|({} (:c ([] 3)) (:a 1) (:b |2) (:d ({} (([] 1 2) 3))))"
                 pr-str $ {}
                   :a 1
                   :b |2
@@ -105,7 +105,7 @@
                 edn-demo "|%{} Person (age 23)\n  name |Chen"
               assert=
                 pr-str $ %{} Person (:name |Chen) (:age 23)
-                , "|%{Person age 23, name |Chen }"
+                , "|(%{} Person (age 23) (name |Chen))"
               assert= edn-demo
                 trim $ write-cirru-edn $ %{} Person (:name |Chen) (:age 23)
 

--- a/tests/snapshots/test.cirru
+++ b/tests/snapshots/test.cirru
@@ -169,14 +169,16 @@
             assert= :true
               try
                 do (echo "|inside try") :true
-                fn (x)
+                fn (error)
 
             assert= :false
               try
-                do (echo "|inside false try") (raise "|error intented") :true
-                fn (x)
+                do (echo "|inside false try")
+                  raise "|error intented" ([] :demo)
+                  , :true
+                fn (error)
                   do
-                    echo "|Caught error"
+                    echo "|Caught error:" error
                     , :false
 
             echo "|Finished testing try"


### PR DESCRIPTION
There's still some conflicts. In Nim, the error is turned into a record with fields of `message` and `data`. While in JavaScript, it's using builtin `Error` object. The are different, hopefully that's not an immediate problem in a dynamically typed language.
